### PR TITLE
Feature/auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/github/aico/AiCoApplication.java
+++ b/src/main/java/com/github/aico/AiCoApplication.java
@@ -2,8 +2,10 @@ package com.github.aico;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AiCoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/github/aico/config/security/CustomerAccessDeniedHandler.java
+++ b/src/main/java/com/github/aico/config/security/CustomerAccessDeniedHandler.java
@@ -1,0 +1,17 @@
+package com.github.aico.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomerAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        accessDeniedException.printStackTrace();
+        response.sendRedirect("/exceptions/access-denied");
+    }
+}

--- a/src/main/java/com/github/aico/config/security/CustomerAuthenticationEntryPoint.java
+++ b/src/main/java/com/github/aico/config/security/CustomerAuthenticationEntryPoint.java
@@ -1,0 +1,17 @@
+package com.github.aico.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomerAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+            throws IOException, ServletException {
+        response.sendRedirect("/exceptions/entrypoint");
+    }
+}

--- a/src/main/java/com/github/aico/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/github/aico/config/security/JwtTokenProvider.java
@@ -1,0 +1,46 @@
+package com.github.aico.config.security;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    @Value("${jwt.secret-key-source}")
+    private  String secretKeySource;
+    private String secretKey;
+    @PostConstruct
+    public void setUp(){
+        secretKey = Base64.getEncoder()
+                .encodeToString(secretKeySource.getBytes());
+    }
+    private final long tokenValidMilisecond = 2000L * 60 * 60; // 2시간
+
+    private final UserDetailsService userDetailsService;
+
+    public String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7); // "Bearer " 접두사 제거
+        }
+        return null;
+    }
+
+
+    public boolean validateToken(String token) {
+
+    }
+
+    public Authentication getAuthentication(String token) {
+    }
+}

--- a/src/main/java/com/github/aico/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/github/aico/config/security/JwtTokenProvider.java
@@ -1,15 +1,24 @@
 package com.github.aico.config.security;
 
+import com.github.aico.repository.userDetails.CustomUserDetails;
+import com.github.aico.service.exceptions.TokenValidateException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
+import java.util.Date;
+import java.util.List;
 
 
 @Slf4j
@@ -27,6 +36,18 @@ public class JwtTokenProvider {
     private final long tokenValidMilisecond = 2000L * 60 * 60; // 2시간
 
     private final UserDetailsService userDetailsService;
+    public String createToken(String email, List<String> roles){
+        Claims claims = Jwts.claims()
+                .setSubject(email);
+        claims.put("roles",roles);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime()+tokenValidMilisecond))
+                .signWith(SignatureAlgorithm.HS256,secretKey)
+                .compact();
+    }
 
     public String resolveToken(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
@@ -38,9 +59,34 @@ public class JwtTokenProvider {
 
 
     public boolean validateToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            Date now = new Date();
+            if (claims.getExpiration().before(now)){
+                throw new TokenValidateException("해당 토큰 유효 기간이 지났습니다.");
+            }
+            return claims.getExpiration().after(now);
+        }catch (TokenValidateException tve){
+            throw new TokenValidateException("토큰이 유효하지 않습니다.");
+        }
 
     }
 
     public Authentication getAuthentication(String token) {
+        String email = getEmail(token);
+        UserDetails userDetails =userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails,"",userDetails.getAuthorities());
+    }
+    public String getEmail(String token){
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
     }
 }

--- a/src/main/java/com/github/aico/config/security/JwtUserArgumentResolver.java
+++ b/src/main/java/com/github/aico/config/security/JwtUserArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.github.aico.config.security;
+
+
+import com.github.aico.repository.user.JwtUser;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user.UserRepository;
+import com.github.aico.repository.userDetails.CustomUserDetails;
+import com.github.aico.service.exceptions.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserRepository userRepository;
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(User.class) &&
+                parameter.hasParameterAnnotation(JwtUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication instanceof UsernamePasswordAuthenticationToken)) {
+            throw new NotFoundException("인증 정보가 없습니다.");
+        }
+
+        // 인증 객체에서 principal 가져오기
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomUserDetails)) {
+            throw new NotFoundException("잘못된 인증 정보입니다.");
+        }
+
+        // UserDetails로 변환
+        CustomUserDetails userDetails = (CustomUserDetails) principal;
+
+        // 데이터베이스에서 유저 조회
+        return userRepository.findByEmailUserFetchJoin(userDetails.getUsername())
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/github/aico/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/github/aico/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package com.github.aico.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder();}
+}

--- a/src/main/java/com/github/aico/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/github/aico/config/security/SecurityConfiguration.java
@@ -1,11 +1,16 @@
 package com.github.aico.config.security;
 
+import com.github.aico.web.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -17,6 +22,27 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfiguration {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .headers((h)->h.frameOptions((f)->f.sameOrigin()))
+                .csrf((c)->c.disable())
+                .httpBasic(hb->hb.disable())
+                .formLogin((fl)->fl.disable())
+                .rememberMe((rm)->rm.disable())
+                .sessionManagement(sm->sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(c-> c.configurationSource(corsConfig()))
+                .authorizeHttpRequests((requests) -> requests
+                        .anyRequest().permitAll()  // 모든 요청에 대해 인증 없이 접근 허용
+                )
+                .exceptionHandling((exception) -> exception
+                        .authenticationEntryPoint(new CustomerAuthenticationEntryPoint())
+                        .accessDeniedHandler(new CustomerAccessDeniedHandler()))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
     private CorsConfigurationSource corsConfig() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowCredentials(false);

--- a/src/main/java/com/github/aico/config/security/WebMvcConfig.java
+++ b/src/main/java/com/github/aico/config/security/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.github.aico.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final JwtUserArgumentResolver jwtUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(jwtUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/github/aico/repository/base/BaseEntity.java
+++ b/src/main/java/com/github/aico/repository/base/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.github.aico.repository.base;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -13,8 +14,10 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
     @CreatedDate
-    private LocalDateTime createAt;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updateAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/github/aico/repository/user/JwtUser.java
+++ b/src/main/java/com/github/aico/repository/user/JwtUser.java
@@ -1,0 +1,11 @@
+package com.github.aico.repository.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtUser {
+}

--- a/src/main/java/com/github/aico/repository/user/User.java
+++ b/src/main/java/com/github/aico/repository/user/User.java
@@ -2,6 +2,8 @@ package com.github.aico.repository.user;
 
 import com.github.aico.repository.base.BaseEntity;
 import com.github.aico.repository.user_role.UserRole;
+import com.github.aico.service.exceptions.BadRequestException;
+import com.github.aico.web.dto.auth.request.SignUpRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -28,4 +30,18 @@ public class User extends BaseEntity {
     private String phoneNumber;
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL,orphanRemoval = true, fetch = FetchType.EAGER)
     private List<UserRole> userRoles;
+
+    public static User from(SignUpRequest signUpRequest){
+        return User.builder()
+                .nickname(signUpRequest.getNickname())
+                .email(signUpRequest.getEmail())
+                .phoneNumber(signUpRequest.getPhoneNumber())
+                .build();
+    }
+    public void updatePassword(String password){
+        if (password == null || password.equals("")) {
+            throw new BadRequestException("비밀번호를 입력해주세요");
+        }
+        this.password = password;
+    }
 }

--- a/src/main/java/com/github/aico/repository/user/UserRepository.java
+++ b/src/main/java/com/github/aico/repository/user/UserRepository.java
@@ -1,8 +1,13 @@
 package com.github.aico.repository.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
+    @Query("SELECT u FROM User u JOIN FETCH u.userRoles ur JOIN FETCH ur.role r WHERE u.email =:email")
+    Optional<User> findByEmailUserFetchJoin(String email);
 }

--- a/src/main/java/com/github/aico/repository/user/UserRepository.java
+++ b/src/main/java/com/github/aico/repository/user/UserRepository.java
@@ -10,4 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User,Long> {
     @Query("SELECT u FROM User u JOIN FETCH u.userRoles ur JOIN FETCH ur.role r WHERE u.email =:email")
     Optional<User> findByEmailUserFetchJoin(String email);
+
+    boolean existsByEmail(String email);
+    boolean existsByNickname (String nickname);
 }

--- a/src/main/java/com/github/aico/repository/userDetails/CustomUserDetails.java
+++ b/src/main/java/com/github/aico/repository/userDetails/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.github.aico.repository.userDetails;
+
+import com.github.aico.repository.role.Role;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user_role.UserRole;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class CustomUserDetails implements UserDetails {
+    private User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return user.getUserRoles().stream()
+                .map(UserRole::getRole)
+                .map(Role::getRoleName)
+                .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return this.user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return this.user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -1,0 +1,109 @@
+package com.github.aico.service.auth;
+
+import com.github.aico.config.security.JwtTokenProvider;
+import com.github.aico.repository.role.Role;
+import com.github.aico.repository.role.RoleRepository;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user.UserRepository;
+import com.github.aico.repository.user_role.UserRole;
+import com.github.aico.repository.user_role.UserRoleRepository;
+import com.github.aico.service.exceptions.NotAcceptException;
+import com.github.aico.service.exceptions.NotFoundException;
+import com.github.aico.web.dto.auth.request.EmailDuplicate;
+import com.github.aico.web.dto.auth.request.LoginRequest;
+import com.github.aico.web.dto.auth.request.NicknameDuplicate;
+import com.github.aico.web.dto.auth.request.SignUpRequest;
+import com.github.aico.web.dto.auth.resposne.DuplicateResult;
+import com.github.aico.web.dto.base.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    /**
+     * 닉네임 중복확인
+     * */
+    public ResponseDto getNickNameDuplicateCheckResult(NicknameDuplicate nicknameDuplicate) {
+        String nickname = nicknameDuplicate.getNickname();
+        if (userRepository.existsByNickname(nickname)){
+            return new ResponseDto(HttpStatus.CONFLICT.value(),"중복확인",DuplicateResult.of(nickname+"은 이미 사용 중입니다.",false) );
+        }else {
+            return new ResponseDto(HttpStatus.OK.value(),"중복확인",DuplicateResult.of(nickname+"은 사용 가능합니다.",true) );
+        }
+    }
+    /**
+     * 이메일 중복확인
+     * */
+    public ResponseDto getEmailDuplicateCheckResult(EmailDuplicate emailDuplicate) {
+        String email = emailDuplicate.getEmail();
+        if (userRepository.existsByEmail(email)){
+            return new ResponseDto(HttpStatus.CONFLICT.value(),"중복확인",DuplicateResult.of(email+"은 이미 사용 중입니다.",false) );
+        }else {
+            return new ResponseDto(HttpStatus.OK.value(),"중복확인",DuplicateResult.of(email+"은 사용 가능합니다.",true) );
+        }
+    }
+    /**
+     * 회원가입
+     * */
+    @Transactional
+    public ResponseDto signUpResult(SignUpRequest signUpRequest) {
+        String email = signUpRequest.getEmail();
+        String nickname = signUpRequest.getNickname();
+        if (userRepository.existsByEmail(email)){
+            return new ResponseDto(HttpStatus.CONFLICT.value(),email+"은 이미 사용 중입니다." );
+        }
+        if (userRepository.existsByNickname(nickname)){
+            return new ResponseDto(HttpStatus.CONFLICT.value(),nickname+"은 이미 사용 중입니다." );
+        }
+        User user = User.from(signUpRequest);
+        user.updatePassword(passwordEncoder.encode(signUpRequest.getPassword()));
+        Role role = roleRepository.findById(1)
+                .orElseThrow(()->new NotFoundException("USER 역할이 존재하지 않습니다."));
+        UserRole userRole = UserRole.of(role,user);
+        userRepository.save(user);
+        userRoleRepository.save(userRole);
+        return new ResponseDto(HttpStatus.CREATED.value(),user.getNickname()+"님 Ai-Co 회원가입이 완료되었습니다.");
+    }
+
+    /**
+     * 로그인
+     * */
+    public String loginResult(LoginRequest loginRequest) {
+        try{
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword())
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            User user = userRepository.findByEmailUserFetchJoin(loginRequest.getEmail())
+                    .orElseThrow(() -> new NotFoundException("User를 찾을 수 없습니다."));
+            List<String> roles = user.getUserRoles()
+                    .stream().map(UserRole::getRole)
+                    .map(Role::getRoleName)
+                    .collect(Collectors.toList());
+
+            return jwtTokenProvider.createToken(loginRequest.getEmail(), roles);
+        }catch (Exception e) {
+            e.printStackTrace();
+            throw new NotAcceptException("로그인 정보가 일치하지 않습니다..");
+        }
+    }
+}

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -14,6 +14,7 @@ import com.github.aico.web.dto.auth.request.LoginRequest;
 import com.github.aico.web.dto.auth.request.NicknameDuplicate;
 import com.github.aico.web.dto.auth.request.SignUpRequest;
 import com.github.aico.web.dto.auth.resposne.DuplicateResult;
+import com.github.aico.web.dto.auth.resposne.UserInfo;
 import com.github.aico.web.dto.base.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -105,5 +106,16 @@ public class AuthService {
             e.printStackTrace();
             throw new NotAcceptException("로그인 정보가 일치하지 않습니다..");
         }
+    }
+
+    public UserInfo getUserInfo(LoginRequest loginRequest) {
+        User user = userRepository.findByEmailUserFetchJoin(loginRequest.getEmail())
+                .orElseThrow(()->new NotFoundException(loginRequest.getEmail()+"에 해당하는 유저를 찾을 수 없습니다."));
+        return UserInfo.from(user);
+
+    }
+
+    public ResponseDto loginValidRequest(User user) {
+
     }
 }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -116,6 +116,6 @@ public class AuthService {
     }
 
     public ResponseDto loginValidRequest(User user) {
-
+        return new ResponseDto(HttpStatus.OK.value(),"토큰이 유효합니다.", UserInfo.from(user));
     }
 }

--- a/src/main/java/com/github/aico/service/exceptions/BadRequestException.java
+++ b/src/main/java/com/github/aico/service/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.github.aico.service.exceptions;
+
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/aico/service/exceptions/CAuthenticationEntryPointException.java
+++ b/src/main/java/com/github/aico/service/exceptions/CAuthenticationEntryPointException.java
@@ -1,0 +1,15 @@
+package com.github.aico.service.exceptions;
+
+public class CAuthenticationEntryPointException extends RuntimeException{
+    public CAuthenticationEntryPointException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public CAuthenticationEntryPointException(String msg) {
+        super(msg);
+    }
+
+    public CAuthenticationEntryPointException() {
+        super();
+    }
+}

--- a/src/main/java/com/github/aico/service/exceptions/NotAcceptException.java
+++ b/src/main/java/com/github/aico/service/exceptions/NotAcceptException.java
@@ -1,0 +1,7 @@
+package com.github.aico.service.exceptions;
+
+public class NotAcceptException extends RuntimeException{
+    public NotAcceptException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/aico/service/exceptions/NotFoundException.java
+++ b/src/main/java/com/github/aico/service/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.github.aico.service.exceptions;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/aico/service/exceptions/TokenValidateException.java
+++ b/src/main/java/com/github/aico/service/exceptions/TokenValidateException.java
@@ -1,0 +1,7 @@
+package com.github.aico.service.exceptions;
+
+public class TokenValidateException extends RuntimeException{
+    public TokenValidateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/aico/service/userDetailsService/CustomUserDetailsService.java
+++ b/src/main/java/com/github/aico/service/userDetailsService/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.github.aico.service.userDetailsService;
+
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user.UserRepository;
+import com.github.aico.repository.userDetails.CustomUserDetails;
+import com.github.aico.service.exceptions.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmailUserFetchJoin(email)
+                .orElseThrow(()->new NotFoundException(email+"에 해당하는 유저를 찾을 수 없습니다."));
+        return CustomUserDetails.builder()
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.github.aico.web.controller.advice;
+
+import com.github.aico.service.exceptions.NotFoundException;
+import com.github.aico.web.dto.base.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseDto handleNotFoundException(NotFoundException nfe){
+        log.error("클라이언트 요청 이후 DB검색 중 발생한 에러입니다. " + nfe.getMessage());
+        return new ResponseDto(HttpStatus.NOT_FOUND.value(),nfe.getMessage());
+    }
+}

--- a/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
@@ -1,9 +1,12 @@
 package com.github.aico.web.controller.advice;
 
+import com.github.aico.service.exceptions.CAuthenticationEntryPointException;
 import com.github.aico.service.exceptions.NotFoundException;
+import com.github.aico.service.exceptions.TokenValidateException;
 import com.github.aico.web.dto.base.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,5 +20,23 @@ public class ExceptionControllerAdvice {
     public ResponseDto handleNotFoundException(NotFoundException nfe){
         log.error("클라이언트 요청 이후 DB검색 중 발생한 에러입니다. " + nfe.getMessage());
         return new ResponseDto(HttpStatus.NOT_FOUND.value(),nfe.getMessage());
+    }
+    @ExceptionHandler(TokenValidateException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseDto handleTokenValidateException(TokenValidateException tve){
+        log.error("클라이언트 요청 중 문제 발생 " + tve.getMessage());
+        return new ResponseDto(HttpStatus.BAD_REQUEST.value(),tve.getMessage());
+    }
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseDto handleAccessDeniedException(AccessDeniedException ade){
+        log.error("Client 요청에 문제가 있어 다음처럼 출력합니다. " + ade.getMessage());
+        return new ResponseDto(HttpStatus.FORBIDDEN.value(),ade.getMessage());
+    }
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(CAuthenticationEntryPointException.class)
+    public ResponseDto handleAuthenticationException(CAuthenticationEntryPointException ae){
+        log.error("Client 요청에 문제가 있어 다음처럼 출력합니다. " + ae.getMessage());
+        return new ResponseDto(HttpStatus.UNAUTHORIZED.value(),ae.getMessage());
     }
 }

--- a/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/github/aico/web/controller/advice/ExceptionControllerAdvice.java
@@ -1,8 +1,6 @@
 package com.github.aico.web.controller.advice;
 
-import com.github.aico.service.exceptions.CAuthenticationEntryPointException;
-import com.github.aico.service.exceptions.NotFoundException;
-import com.github.aico.service.exceptions.TokenValidateException;
+import com.github.aico.service.exceptions.*;
 import com.github.aico.web.dto.base.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -38,5 +36,17 @@ public class ExceptionControllerAdvice {
     public ResponseDto handleAuthenticationException(CAuthenticationEntryPointException ae){
         log.error("Client 요청에 문제가 있어 다음처럼 출력합니다. " + ae.getMessage());
         return new ResponseDto(HttpStatus.UNAUTHORIZED.value(),ae.getMessage());
+    }
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseDto handleBadRequestException(BadRequestException bre){
+        log.error("Client 요청에 문제가 있어 다음처럼 출력합니다. " + bre.getMessage());
+        return new ResponseDto(HttpStatus.BAD_REQUEST.value(),bre.getMessage());
+    }
+    @ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+    @ExceptionHandler(NotAcceptException.class)
+    public ResponseDto handleNotAcceptException(NotAcceptException nae){
+        log.error("클라이언트 요청 이후 DB검색 중 발생한 에러입니다. " + nae.getMessage());
+        return new ResponseDto(HttpStatus.NOT_ACCEPTABLE.value(),nae.getMessage());
     }
 }

--- a/src/main/java/com/github/aico/web/controller/auth/AuthController.java
+++ b/src/main/java/com/github/aico/web/controller/auth/AuthController.java
@@ -1,5 +1,8 @@
 package com.github.aico.web.controller.auth;
 
+import com.github.aico.repository.user.JwtUser;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.userDetails.CustomUserDetails;
 import com.github.aico.service.auth.AuthService;
 import com.github.aico.web.dto.auth.request.EmailDuplicate;
 import com.github.aico.web.dto.auth.request.LoginRequest;
@@ -10,10 +13,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -41,9 +42,17 @@ public class AuthController {
         String  token = authService.loginResult(loginRequest);
         if (token != null && !token.isEmpty()) {
             response.setHeader("Authorization", "Bearer " + token);
-            return new ResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.");
+            return new ResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.",authService.getUserInfo(loginRequest));
         } else {
             return new ResponseDto(HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호를 다시 확인해주세요");
         }
+    }
+    @GetMapping("/login-valid")
+    public ResponseDto loginValid(@JwtUser User user){
+        return authService.loginValidRequest(user);
+    }
+    @GetMapping("/test")
+    public String test(@JwtUser User user){
+        return user.getNickname();
     }
 }

--- a/src/main/java/com/github/aico/web/controller/auth/AuthController.java
+++ b/src/main/java/com/github/aico/web/controller/auth/AuthController.java
@@ -1,0 +1,49 @@
+package com.github.aico.web.controller.auth;
+
+import com.github.aico.service.auth.AuthService;
+import com.github.aico.web.dto.auth.request.EmailDuplicate;
+import com.github.aico.web.dto.auth.request.LoginRequest;
+import com.github.aico.web.dto.auth.request.NicknameDuplicate;
+import com.github.aico.web.dto.auth.request.SignUpRequest;
+import com.github.aico.web.dto.base.ResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/nickname")
+    public ResponseDto nickNameDuplicateCheck(@RequestBody NicknameDuplicate nicknameDuplicate){
+        return authService.getNickNameDuplicateCheckResult(nicknameDuplicate);
+
+    }
+    @PostMapping("/email")
+    public ResponseDto emailDuplicateCheck(@RequestBody EmailDuplicate emailDuplicate){
+        return authService.getEmailDuplicateCheckResult(emailDuplicate);
+
+    }
+    @PostMapping("/sign-up")
+    public ResponseDto signUp(@RequestBody SignUpRequest signUpRequest){
+        return authService.signUpResult(signUpRequest);
+    }
+    @PostMapping("/login")
+    public ResponseDto login(@RequestBody LoginRequest loginRequest, HttpServletResponse response){
+        String  token = authService.loginResult(loginRequest);
+        if (token != null && !token.isEmpty()) {
+            response.setHeader("Authorization", "Bearer " + token);
+            return new ResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.");
+        } else {
+            return new ResponseDto(HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호를 다시 확인해주세요");
+        }
+    }
+}

--- a/src/main/java/com/github/aico/web/controller/exception/ExceptionController.java
+++ b/src/main/java/com/github/aico/web/controller/exception/ExceptionController.java
@@ -1,0 +1,24 @@
+package com.github.aico.web.controller.exception;
+
+import com.github.aico.service.exceptions.CAuthenticationEntryPointException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/exceptions")
+public class ExceptionController {
+
+    @GetMapping(value = "/entrypoint")
+    public void entrypointException() {
+        throw new CAuthenticationEntryPointException( "인증 과정에서 에러");
+    }
+
+    @GetMapping(value = "/access-denied")
+    public void accessdeniedException() {
+        throw new AccessDeniedException("");
+    }
+}

--- a/src/main/java/com/github/aico/web/dto/auth/request/EmailDuplicate.java
+++ b/src/main/java/com/github/aico/web/dto/auth/request/EmailDuplicate.java
@@ -1,0 +1,14 @@
+package com.github.aico.web.dto.auth.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@ToString
+public class EmailDuplicate {
+    private final String email;
+}

--- a/src/main/java/com/github/aico/web/dto/auth/request/LoginRequest.java
+++ b/src/main/java/com/github/aico/web/dto/auth/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.github.aico.web.dto.auth.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@ToString
+public class LoginRequest {
+    private final String email;
+    private final String password;
+}

--- a/src/main/java/com/github/aico/web/dto/auth/request/NicknameDuplicate.java
+++ b/src/main/java/com/github/aico/web/dto/auth/request/NicknameDuplicate.java
@@ -1,0 +1,14 @@
+package com.github.aico.web.dto.auth.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@ToString
+public class NicknameDuplicate {
+    private final String nickname;
+}

--- a/src/main/java/com/github/aico/web/dto/auth/request/SignUpRequest.java
+++ b/src/main/java/com/github/aico/web/dto/auth/request/SignUpRequest.java
@@ -1,0 +1,18 @@
+package com.github.aico.web.dto.auth.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+public class SignUpRequest {
+    private final String nickname;
+    private final String email;
+    private final String password;
+    private final String phoneNumber;
+
+}

--- a/src/main/java/com/github/aico/web/dto/auth/resposne/DuplicateResult.java
+++ b/src/main/java/com/github/aico/web/dto/auth/resposne/DuplicateResult.java
@@ -1,0 +1,21 @@
+package com.github.aico.web.dto.auth.resposne;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class DuplicateResult {
+    private final String message;
+    private final boolean check;
+
+    public static DuplicateResult of(String message, boolean check){
+        return DuplicateResult.builder()
+                .message(message)
+                .check(check)
+                .build();
+    }
+}

--- a/src/main/java/com/github/aico/web/dto/auth/resposne/UserInfo.java
+++ b/src/main/java/com/github/aico/web/dto/auth/resposne/UserInfo.java
@@ -1,0 +1,25 @@
+package com.github.aico.web.dto.auth.resposne;
+
+import com.github.aico.repository.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class UserInfo {
+    private final Long userId;
+    private final String nickname;
+    private final String email;
+    private final String phoneNumber;
+
+    public static UserInfo from(User user){
+        return UserInfo.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/github/aico/web/dto/base/ResponseDto.java
+++ b/src/main/java/com/github/aico/web/dto/base/ResponseDto.java
@@ -1,0 +1,37 @@
+package com.github.aico.web.dto.base;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+public class ResponseDto {
+    private int code;
+    private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Object data;
+
+    public ResponseDto() {
+        this.code = HttpStatus.OK.value();
+        this.message = HttpStatus.OK.name();
+    }
+
+    public ResponseDto(int code, String message) {
+        this.code =code;
+        this.message = message;
+    }
+
+    public ResponseDto(Object data) {
+        this.code = HttpStatus.OK.value();
+        this.message = HttpStatus.OK.name();
+        this.data = data;
+    }
+
+    public ResponseDto(int code, String message, Object data) {
+        this.code =code;
+        this.message = message;
+        this.data= data;
+    }
+}

--- a/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.github.aico.web.filter;
+
+import com.github.aico.config.security.JwtTokenProvider;
+import com.github.aico.service.exceptions.TokenValidateException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = jwtTokenProvider.resolveToken(request);
+        try{
+            if (token != null && jwtTokenProvider.validateToken(token)){
+                Authentication auth = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }catch (Exception e){
+
+        }
+
+        if (token == null){
+            throw new TokenValidateException("토큰이 없거나 유효하지 않습니다.");
+        }
+        filterChain.doFilter(request,response);
+
+    }
+}

--- a/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
@@ -31,9 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throw new TokenValidateException("토큰이 유효하지 않습니다.");
         }
 
-//        if (token == null){
-//            throw new TokenValidateException("토큰이 없거나 유효하지 않습니다.");
-//        }
+
         filterChain.doFilter(request,response);
 
     }

--- a/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
@@ -27,13 +27,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Authentication auth = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
-        }catch (Exception e){
-
+        }catch (TokenValidateException tokenValidateException){
+            throw new TokenValidateException("토큰이 유효하지 않습니다.");
         }
 
-        if (token == null){
-            throw new TokenValidateException("토큰이 없거나 유효하지 않습니다.");
-        }
+//        if (token == null){
+//            throw new TokenValidateException("토큰이 없거나 유효하지 않습니다.");
+//        }
         filterChain.doFilter(request,response);
 
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
       io.netty.resolver.dns: DEBUG
 
 jwt:
-  secret-key-source: ${SECRETKEY}  # JWT ???
+  secret-key-source: ENC(TH3JEhaFp/YER6btYCYQ99ZH9nDc/zuXPIVNM/JnshmEAOsccENF1WNlkkII/0xt)
 jasypt:
   encryptor:
     password: ${JASYPT_SECRET_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,8 +16,8 @@ spring:
     level:
       io.netty.resolver.dns: DEBUG
 
-#jwt:
-#  secret-key-source: ${SECRETKEY}  # JWT ???
+jwt:
+  secret-key-source: ${SECRETKEY}  # JWT ???
 jasypt:
   encryptor:
     password: ${JASYPT_SECRET_KEY}


### PR DESCRIPTION
CustomUserDetails 와 CustomUserDetailsService를 생성하여 로그인 정보와 db가 일치하는지 확인
login : 로그인 정보와 일치하는지 확인 후 유저 정보 출력
signUp : 회원가입할 정보를 받아 비밀번호 암호화 하여 db에 저장
emailDuplicate : 이메일을 받아서 db에 존재하는 이메일이 있는지 확인
nicknameDuplicate : 닉네임을 받아서 db에 존재하는 닉네임이 있는지 확인
login-valid : 토큰이 유효한지 확인 후 유저 정보 출력
JwtTokenProvider : 토큰 관리를 위해 토큰에 대한 로직 bean 생성
JwtAuthenticationFilter : 세션이 아닌 JWT 토큰 사용을 위해 필터 생성 후 시큐리티 컨피그에 해당 필터 추가
JwtArgumentResolver : 토큰에 대한 유저 정보를 받는 로직이 많은 곳에서 반복되어 한곳에서 처리하여 user 정보 출력하도록 ArgumentResolver 생성

error 
1. signUp 시 BaseEntity를 사용하는데 필드와 컬럼명이 달라 SQLException 발생  -> 필드명과 컬럼명을 일치시켜해결 완료
2. SecretKey가 32비트가 넘지 않아  The signing key's size is 224 bits which is not secure enough for the HS256 algorithm. 에러 발생 -> 32비트를 넘겨서 해결 완료