### PR TITLE
Refactor/auth refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     //redis에 Jackson사용
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/src/main/java/com/github/aico/AiCoApplication.java
+++ b/src/main/java/com/github/aico/AiCoApplication.java
@@ -2,12 +2,14 @@ package com.github.aico;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableCaching
 public class AiCoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -129,8 +129,9 @@ public class AuthService {
                     .stream().map(UserRole::getRole)
                     .map(Role::getRoleName)
                     .collect(Collectors.toList());
-            String refresh = jwtTokenProvider.createRefreshToken(loginRequest.getEmail());
+
             if (!refreshTokenRepository.existsByUser(user)){
+                String refresh = jwtTokenProvider.createRefreshToken(loginRequest.getEmail());
                 RefreshToken refreshToken = RefreshToken.of(user,refresh);
                 refreshTokenRepository.save(refreshToken);
             }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -240,7 +240,8 @@ public class AuthService {
     }
 
     public void logoutResult(User user,HttpServletResponse response) {
-        deleteCookie(response);
         refreshTokenRepository.findByUser(user).ifPresent(refreshTokenRepository::delete);
+        deleteCookie(response);
+
     }
 }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -141,6 +141,9 @@ public class AuthService {
             throw new NotAcceptException("로그인 정보가 일치하지 않습니다..");
         }
     }
+    /**
+     * 유저 정보 출력
+     * */
 
     public UserInfo getUserInfo(LoginRequest loginRequest) {
         User user = userRepository.findByEmailUserFetchJoin(loginRequest.getEmail())
@@ -150,13 +153,17 @@ public class AuthService {
         return UserInfo.of(user,userProfileImage.getImageUrl());
 
     }
-
+    /**
+     *로그인 유지되고 있는지
+     * */
     public ResponseDto loginValidRequest(User user) {
         UserProfileImage userProfileImage = userProfileImageRepository.findByUser(user)
                 .orElseThrow(()->new NotFoundException("유저에 해당하는 프로필이 없습니다."));
         return new ResponseDto(HttpStatus.OK.value(),"토큰이 유효합니다.", UserInfo.of(user,userProfileImage.getImageUrl()));
     }
-
+    /**
+    *토큰 재발급
+    * */
     public ResponseDto refreshToken(String accessToken, HttpServletResponse response) {
         String email = jwtTokenProvider.getEmail(accessToken);
         if (email == null) {
@@ -176,38 +183,10 @@ public class AuthService {
         createCookie(newAccessToken,response);
         return new ResponseDto(HttpStatus.CREATED.value(),"새로운 토큰이 발급되었습니다.");
     }
-    private void deleteCookie(HttpServletResponse response){
-//        Cookie oldCookie = new Cookie("access_token", null);
-//        oldCookie.setHttpOnly(true);
-////        oldCookie.setSecure(true);
-//        oldCookie.setPath("/");
-//        oldCookie.setMaxAge(0);
-//        response.addCookie(oldCookie);
-        ResponseCookie cookie = ResponseCookie.from("Authorization",null)
-                .httpOnly(true)
-                .secure(true) // https 환경에서 true로 설정
-                .path("/")
-                .maxAge(0)
-                .sameSite("None") // SameSite 설정
-                .build();
-        response.addHeader("Set-Cookie",cookie.toString());
-    }
-    private void createCookie(String newAccessToken,HttpServletResponse response){
-//        Cookie newCookie = new Cookie("access_token", newAccessToken);
-//        newCookie.setHttpOnly(true);
-////        newCookie.setSecure(true);
-//        newCookie.setPath("/");
-//        newCookie.setMaxAge(60 * 60 * 24);
-//        response.addCookie(newCookie);
-        ResponseCookie cookie = ResponseCookie.from("Authorization", newAccessToken)
-                .httpOnly(true)
-                .secure(true) // https 환경에서 true로 설정
-                .path("/")
-                .maxAge(60 * 60 * 24)
-                .sameSite("None") // SameSite 설정
-                .build();
-        response.addHeader("Set-Cookie",cookie.toString());
-    }
+    /**
+     * 메소드
+     * */
+
     /**
      * team가입
      * */
@@ -237,5 +216,26 @@ public class AuthService {
         TeamUser teamUser = TeamUser.of(joinTeam, saveUser, TeamRole.MEMBER);
         teamUserRepository.save(teamUser);
 
+    }
+
+    private void deleteCookie(HttpServletResponse response){
+        ResponseCookie cookie = ResponseCookie.from("Authorization",null)
+                .httpOnly(true)
+                .secure(true) // https 환경에서 true로 설정
+                .path("/")
+                .maxAge(0)
+                .sameSite("None") // SameSite 설정
+                .build();
+        response.addHeader("Set-Cookie",cookie.toString());
+    }
+    private void createCookie(String newAccessToken,HttpServletResponse response){
+        ResponseCookie cookie = ResponseCookie.from("Authorization", newAccessToken)
+                .httpOnly(true)
+                .secure(true) // https 환경에서 true로 설정
+                .path("/")
+                .maxAge(60 * 60 * 24)
+                .sameSite("None") // SameSite 설정
+                .build();
+        response.addHeader("Set-Cookie",cookie.toString());
     }
 }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -31,6 +31,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -63,7 +65,7 @@ public class AuthService {
 
     /**
      * 닉네임 중복확인
-     * */
+     **/
     public ResponseDto getNickNameDuplicateCheckResult(NicknameDuplicate nicknameDuplicate) {
         String nickname = nicknameDuplicate.getNickname();
         if (userRepository.existsByNickname(nickname)){
@@ -74,7 +76,7 @@ public class AuthService {
     }
     /**
      * 이메일 중복확인
-     * */
+     **/
     public ResponseDto getEmailDuplicateCheckResult(EmailDuplicate emailDuplicate) {
         String email = emailDuplicate.getEmail();
         if (userRepository.existsByEmail(email)){
@@ -85,7 +87,7 @@ public class AuthService {
     }
     /**
      * 회원가입
-     * */
+     **/
     @Transactional
     public ResponseDto signUpResult(SignUpRequest signUpRequest,String token) {
         String email = signUpRequest.getEmail();
@@ -112,11 +114,9 @@ public class AuthService {
         return new ResponseDto(HttpStatus.CREATED.value(),user.getNickname()+"님 Ai-Co 회원가입이 완료되었습니다.");
     }
 
-
-
     /**
      * 로그인
-     * */
+     **/
     public String loginResult(LoginRequest loginRequest) {
         try{
             Authentication authentication = authenticationManager.authenticate(
@@ -139,15 +139,10 @@ public class AuthService {
             throw new NotAcceptException("로그인 정보가 일치하지 않습니다..");
         }
     }
-    public void createRefreshToken(User user,String email){
-        String refresh = jwtTokenProvider.createRefreshToken(email);
-        RefreshToken refreshToken = RefreshToken.of(user,refresh);
-        refreshTokenRepository.save(refreshToken);
-    }
+
     /**
      * 유저 정보 출력
-     * */
-
+     **/
     public UserInfo getUserInfo(LoginRequest loginRequest) {
         User user = userRepository.findByEmailUserFetchJoin(loginRequest.getEmail())
                 .orElseThrow(()->new NotFoundException(loginRequest.getEmail()+"에 해당하는 유저를 찾을 수 없습니다."));
@@ -158,7 +153,8 @@ public class AuthService {
     }
     /**
      *로그인 유지되고 있는지
-     * */
+     **/
+//    @Cacheable(value = "userInfo", key = "#user.userId")
     public ResponseDto loginValidRequest(User user) {
         UserProfileImage userProfileImage = userProfileImageRepository.findByUser(user)
                 .orElseThrow(()->new NotFoundException("유저에 해당하는 프로필이 없습니다."));
@@ -166,7 +162,7 @@ public class AuthService {
     }
     /**
     *토큰 재발급
-    * */
+    **/
     public ResponseDto refreshToken(String accessToken, HttpServletResponse response) {
         String email = jwtTokenProvider.getEmail(accessToken);
         if (email == null) {
@@ -187,12 +183,21 @@ public class AuthService {
         return new ResponseDto(HttpStatus.CREATED.value(),"새로운 토큰이 발급되었습니다.");
     }
     /**
+     * 로그아웃
+     **/
+//    @CacheEvict(value = "userInfo",key = "#user.userId")
+    public void logoutResult(User user,HttpServletResponse response) {
+        refreshTokenRepository.findByUser(user).ifPresent(refreshTokenRepository::delete);
+        deleteCookie(response);
+    }
+
+    /**
      * 메소드
      * */
 
     /**
      * team가입
-     * */
+     **/
     private void joinTeam(String token, SignUpRequest signUpRequest,User saveUser) {
         String tokenEmail = jwtTokenProvider.getEmail(token);
         Long tokenTeamId = jwtTokenProvider.getTeamId(token);
@@ -220,7 +225,9 @@ public class AuthService {
         teamUserRepository.save(teamUser);
 
     }
-
+    /**
+     * Cookie 삭제
+     * */
     private void deleteCookie(HttpServletResponse response){
         ResponseCookie cookie = ResponseCookie.from("Authorization",null)
                 .httpOnly(true)
@@ -231,6 +238,9 @@ public class AuthService {
                 .build();
         response.addHeader("Set-Cookie",cookie.toString());
     }
+    /**
+     * Cookie 생성
+     * */
     public void createCookie(String newAccessToken,HttpServletResponse response){
         ResponseCookie cookie = ResponseCookie.from("Authorization", newAccessToken)
                 .httpOnly(true)
@@ -241,10 +251,14 @@ public class AuthService {
                 .build();
         response.addHeader("Set-Cookie",cookie.toString());
     }
-
-    public void logoutResult(User user,HttpServletResponse response) {
-        refreshTokenRepository.findByUser(user).ifPresent(refreshTokenRepository::delete);
-        deleteCookie(response);
-
+    /**
+     * refreshToken 생성
+     * */
+    public void createRefreshToken(User user,String email){
+        String refresh = jwtTokenProvider.createRefreshToken(email);
+        RefreshToken refreshToken = RefreshToken.of(user,refresh);
+        refreshTokenRepository.save(refreshToken);
     }
+
+
 }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -129,18 +129,20 @@ public class AuthService {
                     .stream().map(UserRole::getRole)
                     .map(Role::getRoleName)
                     .collect(Collectors.toList());
-
+            //refreshToken 존재 여부 확인 후
             if (!refreshTokenRepository.existsByUser(user)){
-                String refresh = jwtTokenProvider.createRefreshToken(loginRequest.getEmail());
-                RefreshToken refreshToken = RefreshToken.of(user,refresh);
-                refreshTokenRepository.save(refreshToken);
+                createRefreshToken(user,loginRequest.getEmail());
             }
-
             return jwtTokenProvider.createToken(loginRequest.getEmail(), roles);
         }catch (Exception e) {
             e.printStackTrace();
             throw new NotAcceptException("로그인 정보가 일치하지 않습니다..");
         }
+    }
+    public void createRefreshToken(User user,String email){
+        String refresh = jwtTokenProvider.createRefreshToken(email);
+        RefreshToken refreshToken = RefreshToken.of(user,refresh);
+        refreshTokenRepository.save(refreshToken);
     }
     /**
      * 유저 정보 출력
@@ -229,7 +231,7 @@ public class AuthService {
                 .build();
         response.addHeader("Set-Cookie",cookie.toString());
     }
-    private void createCookie(String newAccessToken,HttpServletResponse response){
+    public void createCookie(String newAccessToken,HttpServletResponse response){
         ResponseCookie cookie = ResponseCookie.from("Authorization", newAccessToken)
                 .httpOnly(true)
                 .secure(true) // https 환경에서 true로 설정

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -238,4 +238,9 @@ public class AuthService {
                 .build();
         response.addHeader("Set-Cookie",cookie.toString());
     }
+
+    public void logoutResult(User user,HttpServletResponse response) {
+        deleteCookie(response);
+        refreshTokenRepository.findByUser(user).ifPresent(refreshTokenRepository::delete);
+    }
 }

--- a/src/main/java/com/github/aico/web/controller/auth/AuthController.java
+++ b/src/main/java/com/github/aico/web/controller/auth/AuthController.java
@@ -46,46 +46,22 @@ public class AuthController {
         return authService.signUpResult(signUpRequest,token);
     }
     @PostMapping("/logout")
-    public ResponseDto logout(HttpServletResponse response){
-        ResponseCookie cookie = ResponseCookie.from("Authorization", null)
-                .httpOnly(true)
-                .secure(true) // https 환경에서 true로 설정
-                .path("/")
-                .maxAge(0)
-                .sameSite("None") // SameSite 설정
-                .build();
-        response.addHeader("Set-Cookie",cookie.toString());
+    public ResponseDto logout(@JwtUser User user, HttpServletResponse response){
+        authService.logoutResult(user,response);
+
         return new ResponseDto(HttpStatus.OK.value(), "로그아웃 성공");
     }
     @PostMapping("/login")
     public ResponseDto login(@RequestBody LoginRequest loginRequest, HttpServletResponse response){
         String  token = authService.loginResult(loginRequest);
         if (token != null && !token.isEmpty()) {
-////            response.setHeader("Authorization", "Bearer " + token);
-//            Cookie cookie = new Cookie("access_token", token);
-//            cookie.setHttpOnly(true);
-////            cookie.setSecure(true);
-//            cookie.setPath("/");
-//            cookie.setMaxAge(60 * 60 * 24);
-//            cookie.setAttribute("SameSite","None");
-//
-//            response.addCookie(cookie);
-
             ResponseCookie cookie = ResponseCookie.from("Authorization", token)
                     .httpOnly(true)
                     .secure(true) // https 환경에서 true로 설정
                     .path("/")
                     .maxAge(60 * 60 * 24)
-//                    .domain("ai-co.usze.xyz")
                     .sameSite("None") // SameSite 설정
                     .build();
-//            Cookie cookie = new Cookie("Authorization", token);
-//            cookie.setHttpOnly(true);
-//            cookie.setSecure(true);
-//            cookie.setPath("/");
-//            cookie.setMaxAge(60 * 60 * 24);
-////            cookie.setDomain("www.ai-co.store");
-//            cookie.setAttribute("SameSite","None");/
 
             response.addHeader("Set-Cookie",cookie.toString());
 
@@ -100,8 +76,6 @@ public class AuthController {
     }
     @GetMapping("/test")
     public UserInfo test(@AuthenticationPrincipal CustomUserDetails customUserDetails){
-
-
         User user1 = userRepository.findByEmailWithRoles(customUserDetails.getUsername()).orElseThrow(()-> new NotFoundException("유저 찾기 불가"));
         return UserInfo.from(user1);
     }

--- a/src/main/java/com/github/aico/web/controller/auth/AuthController.java
+++ b/src/main/java/com/github/aico/web/controller/auth/AuthController.java
@@ -55,16 +55,7 @@ public class AuthController {
     public ResponseDto login(@RequestBody LoginRequest loginRequest, HttpServletResponse response){
         String  token = authService.loginResult(loginRequest);
         if (token != null && !token.isEmpty()) {
-            ResponseCookie cookie = ResponseCookie.from("Authorization", token)
-                    .httpOnly(true)
-                    .secure(true) // https 환경에서 true로 설정
-                    .path("/")
-                    .maxAge(60 * 60 * 24)
-                    .sameSite("None") // SameSite 설정
-                    .build();
-
-            response.addHeader("Set-Cookie",cookie.toString());
-
+            authService.createCookie(token,response);
             return new ResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.",authService.getUserInfo(loginRequest));
         } else {
             return new ResponseDto(HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호를 다시 확인해주세요");

--- a/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/aico/web/filter/JwtAuthenticationFilter.java
@@ -36,7 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         new MvcRequestMatcher(introspector, "/api/auth/**"),
                         new MvcRequestMatcher(introspector, "/api/team/join/**")
                 ),
-                new NegatedRequestMatcher(new MvcRequestMatcher(introspector, "/api/auth/login-valid")) // 제외할 URL
+                new NegatedRequestMatcher( // 제외할 URL들
+                        new OrRequestMatcher(
+                                new MvcRequestMatcher(introspector, "/api/auth/login-valid"),
+                                new MvcRequestMatcher(introspector, "/api/auth/logout")
+                        )
+                )
         );
         if (permitAllMatcher.matches(request)) {
             filterChain.doFilter(request, response);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,8 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: none
+#  cache:
+#    type: simple
 
     properties:
       hibernate.jdbc.batch_size: 50  # 한 번에 저장할 최대 엔티티 수


### PR DESCRIPTION
auth refactor

- logout refactoring 
1) 기존 로그 아웃 코드는 쿠키만 제거
-> 쿠키 서비스단에서 처리하도록 변경
-> 해당 유저에 대한 리프레쉬 토큰 제거 추가
2) 기존 로그아웃 코드 시큐리티 필텀 검증에 제외
->로그아웃도 시큐리티 필터에 검증 추가
3) 기존 유저에 대한 리프레쉬 토큰이 있는지 확인하기 전부터 리프레쉬 토큰을 만드는 로직이 있음
-> 리프레쉬 토큰 만들기 전에 존재여부부터 확인 후 생성