### PR TITLE
Feature/add chatting service

### DIFF
--- a/src/main/java/com/github/aico/config/redis/RedisConfig.java
+++ b/src/main/java/com/github/aico/config/redis/RedisConfig.java
@@ -2,6 +2,7 @@ package com.github.aico.config.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.aico.web.dto.chat.request.ActiveTeamUser;
 import com.github.aico.web.dto.chat.request.Chatting;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,21 @@ public class RedisConfig {
         template.setHashValueSerializer(serializer);
 //        template.setKeySerializer(new StringRedisSerializer());
 //        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Chatting.class));
+        return template;
+    }
+    @Bean
+    public RedisTemplate<String, ActiveTeamUser> activeTeamUserRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, ActiveTeamUser> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        // Jackson Serializer 설정
+        Jackson2JsonRedisSerializer<ActiveTeamUser> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, ActiveTeamUser.class);
+        // Serializer 적용
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
         return template;
     }
     @Bean

--- a/src/main/java/com/github/aico/config/redis/RedisConfig.java
+++ b/src/main/java/com/github/aico/config/redis/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -20,7 +21,6 @@ public class RedisConfig {
         objectMapper.registerModule(new JavaTimeModule());
         // Jackson Serializer 설정
         Jackson2JsonRedisSerializer<Chatting> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, Chatting.class);
-
         // Serializer 적용
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(serializer);
@@ -28,6 +28,14 @@ public class RedisConfig {
         template.setHashValueSerializer(serializer);
 //        template.setKeySerializer(new StringRedisSerializer());
 //        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Chatting.class));
+        return template;
+    }
+    @Bean
+    public RedisTemplate<String,Long> longRedisTemplate(RedisConnectionFactory connectionFactory){
+        RedisTemplate<String,Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
         return template;
     }
 }

--- a/src/main/java/com/github/aico/config/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/github/aico/config/websocket/WebSocketEventListener.java
@@ -1,0 +1,44 @@
+package com.github.aico.config.websocket;
+
+import com.github.aico.repository.team.TeamRepository;
+import com.github.aico.repository.team_user.TeamUser;
+import com.github.aico.repository.team_user.TeamUserRepository;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user.UserRepository;
+import com.github.aico.service.chatting.ChattingService;
+import com.github.aico.service.exceptions.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+
+    private final TeamUserRepository teamUserRepository;
+
+    private final UserRepository userRepository;
+    //유저가 웹소켓연결이 모종의 이유로 끊겼을 때 유저가 읽은 시간 처리
+    @EventListener
+    @Transactional
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        String userEmail =  headerAccessor.getSessionAttributes().get("email").toString();
+        if (userEmail != null) {
+            log.info("끊긴 유저의 이메일 값 : " +  userEmail);
+            User user = userRepository.findByEmailWithRoles(userEmail)
+                    .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
+            List<TeamUser> myTeamUsers = teamUserRepository.findAllByUser(user);
+            myTeamUsers.forEach(TeamUser::updateChatReadAt);
+        } else {
+            log.warn("유저에 해당하는 세션이 남아있지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/github/aico/config/websocket/WebsocketConfig.java
+++ b/src/main/java/com/github/aico/config/websocket/WebsocketConfig.java
@@ -2,7 +2,14 @@ package com.github.aico.config.websocket;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -24,5 +31,19 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins("*");
 //                .addInterceptors(jwtHandshakeInterceptor);
 
+    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                if (auth != null && accessor.getCommand() != null) {
+                    accessor.setUser(auth);
+                }
+                return message;
+            }
+        });
     }
 }

--- a/src/main/java/com/github/aico/repository/chat/ChatRepository.java
+++ b/src/main/java/com/github/aico/repository/chat/ChatRepository.java
@@ -5,12 +5,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
-public interface ChatRepository extends JpaRepository<Chat,Long>,CustomChatRepository {
+public interface ChatRepository extends JpaRepository<Chat,Long>,CustomChatRepository, QChatRepository {
 
     Page<Chat> findByTeamUserInOrderByCreatedAtMillisDesc(List<TeamUser> teamUsers, Pageable pageable);
+//    @Query("SELECT new com.github.aico.repository.chat.TeamLatestChatTimeDto(c.teamUser.team.teamId, MAX(c.createdAtMillis)) " +
+//            "FROM Chat c WHERE c.teamUser.team.teamId IN :teamIds GROUP BY c.teamUser.team.teamId")
+//    List<TeamLatestChatTimeDto> findLatestChatTimesByTeamIds(@Param("teamIds") List<Long> teamIds);
+
+
 }

--- a/src/main/java/com/github/aico/repository/chat/ChatRepository.java
+++ b/src/main/java/com/github/aico/repository/chat/ChatRepository.java
@@ -1,5 +1,6 @@
 package com.github.aico.repository.chat;
 
+import com.github.aico.repository.team_user.CustomTeamUserRepository;
 import com.github.aico.repository.team_user.TeamUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat,Long>,CustomChatRepository, QChatRepository {
-
+    @EntityGraph(attributePaths = {"teamUser", "teamUser.user", "teamUser.user.userProfileImage"})
     Page<Chat> findByTeamUserInOrderByCreatedAtMillisDesc(List<TeamUser> teamUsers, Pageable pageable);
 //    @Query("SELECT new com.github.aico.repository.chat.TeamLatestChatTimeDto(c.teamUser.team.teamId, MAX(c.createdAtMillis)) " +
 //            "FROM Chat c WHERE c.teamUser.team.teamId IN :teamIds GROUP BY c.teamUser.team.teamId")

--- a/src/main/java/com/github/aico/repository/chat/CustomChatRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/chat/CustomChatRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.github.aico.repository.chat;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,7 @@ import java.sql.Timestamp;
 import java.util.List;
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class CustomChatRepositoryImpl implements CustomChatRepository {
     private final JdbcTemplate jdbcTemplate;
 
@@ -18,7 +20,8 @@ public class CustomChatRepositoryImpl implements CustomChatRepository {
     public void saveAllBatch(List<Chat> chats) {
         String sql = "INSERT INTO chat (team_user_id, content,created_at,updated_at,created_at_millis) " +
                 "VALUES (?, ?, ?, ?, ?)";
-        jdbcTemplate.batchUpdate(sql,
+        log.info("배치 삽입 시작, 삽입할 데이터 크기: {}", chats.size());
+        int[] updateCounts =jdbcTemplate.batchUpdate(sql,
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -37,6 +40,13 @@ public class CustomChatRepositoryImpl implements CustomChatRepository {
                         return chats.size();
                     }
                 });
+        log.info("배치 삽입 완료, 처리된 행 수: {}", updateCounts.length);
+        //  각 행별 성공 여부 확인
+        for (int i = 0; i < updateCounts.length; i++) {
+            if (updateCounts[i] == 0) {
+                log.warn("행 {} 삽입 실패", i);
+            }
+        }
 
     }
 }

--- a/src/main/java/com/github/aico/repository/chat/QChatRepository.java
+++ b/src/main/java/com/github/aico/repository/chat/QChatRepository.java
@@ -1,0 +1,7 @@
+package com.github.aico.repository.chat;
+
+import java.util.List;
+
+public interface QChatRepository {
+    List<TeamLatestChatTimeDto> findLatestChatTimesByTeamIds(List<Long> teamIds);
+}

--- a/src/main/java/com/github/aico/repository/chat/QChatRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/chat/QChatRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.github.aico.repository.chat;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.github.aico.repository.chat.QChat.chat;
+
+@Repository
+@RequiredArgsConstructor
+public class QChatRepositoryImpl implements QChatRepository{
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<TeamLatestChatTimeDto> findLatestChatTimesByTeamIds(List<Long> teamIds) {
+        return queryFactory
+                .select(Projections.constructor(
+                        TeamLatestChatTimeDto.class,
+                        chat.teamUser.team.teamId,
+                        chat.createdAtMillis.max()
+                ))
+                .from(chat)
+                .where(chat.teamUser.team.teamId.in(teamIds))
+                .groupBy(chat.teamUser.team.teamId)
+                .fetch();
+    }
+}

--- a/src/main/java/com/github/aico/repository/chat/TeamLatestChatTimeDto.java
+++ b/src/main/java/com/github/aico/repository/chat/TeamLatestChatTimeDto.java
@@ -1,0 +1,17 @@
+package com.github.aico.repository.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@ToString
+@Builder
+public class TeamLatestChatTimeDto {
+    private final Long teamId;
+    private final LocalDateTime latestTime;
+}

--- a/src/main/java/com/github/aico/repository/team_user/CustomTeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/CustomTeamUserRepository.java
@@ -1,0 +1,8 @@
+package com.github.aico.repository.team_user;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public interface CustomTeamUserRepository {
+    void updateChatReadAtBulk(Long userId, Map<Long, LocalDateTime> teamIdToLastReadAt);
+}

--- a/src/main/java/com/github/aico/repository/team_user/CustomTeamUserRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/team_user/CustomTeamUserRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.github.aico.repository.team_user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomTeamUserRepositoryImpl implements CustomTeamUserRepository{
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void updateChatReadAtBulk(Long userId, Map<Long, LocalDateTime> teamIdToLastReadAt) {
+        if (teamIdToLastReadAt.isEmpty()) {
+            return;
+        }
+
+        // CASE WHEN 동적 생성
+        StringBuilder caseClause = new StringBuilder();
+        for (Map.Entry<Long, LocalDateTime> entry : teamIdToLastReadAt.entrySet()) {
+            caseClause.append(String.format("WHEN %d THEN ? ", entry.getKey()));
+        }
+
+        // IN 절 동적 생성
+        List<Long> teamIds = new ArrayList<>(teamIdToLastReadAt.keySet());
+        String inClause = String.join(",", Collections.nCopies(teamIds.size(), "?"));
+
+        // SQL 쿼리
+        String sql = String.format(
+                "UPDATE team_user " +
+                        "SET chat_read_at = CASE team_id %s ELSE chat_read_at END " +
+                        "WHERE user_id = ? AND team_id IN (%s)",
+                caseClause.toString(),
+                inClause
+        );
+
+        // 파라미터 준비
+        List<Object> params = new ArrayList<>();
+        params.addAll(teamIdToLastReadAt.values()); // WHEN 절의 값들
+        params.add(userId);                         // WHERE user_id
+        params.addAll(teamIds);                     // WHERE team_id IN
+
+        // 실행
+        jdbcTemplate.update(sql, params.toArray());
+    }
+}

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
@@ -9,4 +9,5 @@ public interface QTeamUserRepository {
     List<TeamUser> findByTeamAndRoleWithLockDsl(Team team, TeamRole role);
     List<TeamUser> findByTeamWithLockDsl(Team team);
     List<Long> findTeamIdsByUser(Long userId);
+    List<Long> findTeamUserIdsByTeam(Long teamId);
 }

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
@@ -1,8 +1,11 @@
 package com.github.aico.repository.team_user;
 
 import com.github.aico.repository.team.Team;
+import com.github.aico.repository.user.User;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public interface QTeamUserRepository {
     List<TeamUser> findTeamUsersByTeamFetchUser(Team team);
@@ -10,4 +13,5 @@ public interface QTeamUserRepository {
     List<TeamUser> findByTeamWithLockDsl(Team team);
     List<Long> findTeamIdsByUser(Long userId);
     List<Long> findTeamUserIdsByTeam(Long teamId);
+
 }

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepository.java
@@ -8,4 +8,5 @@ public interface QTeamUserRepository {
     List<TeamUser> findTeamUsersByTeamFetchUser(Team team);
     List<TeamUser> findByTeamAndRoleWithLockDsl(Team team, TeamRole role);
     List<TeamUser> findByTeamWithLockDsl(Team team);
+    List<Long> findTeamIdsByUser(Long userId);
 }

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
@@ -1,14 +1,24 @@
 package com.github.aico.repository.team_user;
 
-import com.github.aico.repository.team.QTeam;
+
 import com.github.aico.repository.team.Team;
 import com.github.aico.repository.user.QUser;
+import com.github.aico.repository.user.QUserProfileImage;
+import com.github.aico.repository.user.User;
+
+
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static com.github.aico.repository.team_user.QTeamUser.teamUser;
 
@@ -21,10 +31,12 @@ public class QTeamUserRepositoryImpl implements QTeamUserRepository {
     public List<TeamUser> findTeamUsersByTeamFetchUser(Team team) {
         QTeamUser teamUser = QTeamUser.teamUser;
         QUser user = QUser.user;
+        QUserProfileImage userProfileImage = QUserProfileImage.userProfileImage;
 
 
         return jpaQueryFactory.selectFrom(teamUser)
                 .join(teamUser.user,user).fetchJoin()
+                .join(user.userProfileImage, userProfileImage).fetchJoin()
                 .where(teamUser.team.eq( team))
                 .fetch();
     }
@@ -44,6 +56,10 @@ public class QTeamUserRepositoryImpl implements QTeamUserRepository {
                 .where(teamUser.team.teamId.eq(teamId))
                 .fetch();
     }
+
+
+
+
     @Override
     public List<TeamUser> findByTeamWithLockDsl(Team team) {
         QTeamUser teamUser = QTeamUser.teamUser;

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
@@ -37,6 +37,14 @@ public class QTeamUserRepositoryImpl implements QTeamUserRepository {
                 .fetch();
     }
     @Override
+    public List<Long> findTeamUserIdsByTeam(Long teamId) {
+        return jpaQueryFactory
+                .select(teamUser.user.userId)
+                .from(teamUser)
+                .where(teamUser.team.teamId.eq(teamId))
+                .fetch();
+    }
+    @Override
     public List<TeamUser> findByTeamWithLockDsl(Team team) {
         QTeamUser teamUser = QTeamUser.teamUser;
 

--- a/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
+++ b/src/main/java/com/github/aico/repository/team_user/QTeamUserRepositoryImpl.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.github.aico.repository.team_user.QTeamUser.teamUser;
+
 @Repository
 @RequiredArgsConstructor
 public class QTeamUserRepositoryImpl implements QTeamUserRepository {
@@ -24,6 +26,14 @@ public class QTeamUserRepositoryImpl implements QTeamUserRepository {
         return jpaQueryFactory.selectFrom(teamUser)
                 .join(teamUser.user,user).fetchJoin()
                 .where(teamUser.team.eq( team))
+                .fetch();
+    }
+    @Override
+    public List<Long> findTeamIdsByUser(Long userId) {
+        return jpaQueryFactory
+                .select(teamUser.team.teamId)
+                .from(teamUser)
+                .where(teamUser.user.userId.eq(userId))
                 .fetch();
     }
     @Override

--- a/src/main/java/com/github/aico/repository/team_user/TeamUser.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUser.java
@@ -42,5 +42,8 @@ public class TeamUser {
     public void updateChatReadAt(){
         this.chatReadAt = LocalDateTime.now();
     }
+    public void changeChatReadAt(LocalDateTime chatReadAt){
+        this.chatReadAt = chatReadAt;
+    }
 
 }

--- a/src/main/java/com/github/aico/repository/team_user/TeamUser.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUser.java
@@ -5,6 +5,8 @@ import com.github.aico.repository.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,6 +25,8 @@ public class TeamUser {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id")
     private User user;
+    @Column(name = "chat_read_at")
+    private LocalDateTime chatReadAt;
     @Enumerated(EnumType.STRING)
     @Column(name = "team_role",nullable = false)
     private TeamRole teamRole;
@@ -32,7 +36,11 @@ public class TeamUser {
                 .team(team)
                 .user(user)
                 .teamRole(teamRole)
+                .chatReadAt(LocalDateTime.now())
                 .build();
+    }
+    public void updateChatReadAt(){
+        this.chatReadAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
@@ -23,6 +23,7 @@ public interface TeamUserRepository extends JpaRepository<TeamUser,Long>, QTeamU
     Optional<TeamUser> findByTeamAndUser(Team team, User user);
     Optional<TeamUser> findByTeamTeamIdAndUserId(Long teamId, Long userId);    boolean existsByTeamAndUser(Team team, User user);
 
+    List<TeamUser> findAllByUser(User user);
     List<TeamUser> findAllByTeam(Team team);
 //    @Query("SELECT tu FROM TeamUser tu JOIN FETCH tu.user WHERE tu.team = :team")
 //    List<TeamUser> findAllByTeamFetchUser(Team team);

--- a/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 public interface TeamUserRepository extends JpaRepository<TeamUser,Long>, QTeamUserRepository {
     @EntityGraph(attributePaths = {"team"})
     Page<TeamUser> findAllByUser(User user, Pageable pageable);
+    @EntityGraph(attributePaths = {"team"})
+    List<TeamUser> findByUserAndTeamTeamIdIn(User user, List<Long> teamIds);
 
     Optional<TeamUser> findByTeamAndUser(Team team, User user);
     Optional<TeamUser> findByTeamTeamIdAndUserId(Long teamId, Long userId);    boolean existsByTeamAndUser(Team team, User user);

--- a/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
@@ -5,28 +5,37 @@ import com.github.aico.repository.user.User;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface TeamUserRepository extends JpaRepository<TeamUser,Long>, QTeamUserRepository {
+public interface TeamUserRepository extends JpaRepository<TeamUser,Long>, QTeamUserRepository, CustomTeamUserRepository {
     @EntityGraph(attributePaths = {"team"})
     Page<TeamUser> findAllByUser(User user, Pageable pageable);
     @EntityGraph(attributePaths = {"team"})
     List<TeamUser> findByUserAndTeamTeamIdIn(User user, List<Long> teamIds);
+    @EntityGraph(attributePaths = {"user", "user.userProfileImage"})
+    List<TeamUser> findByTeamAndUserIdIn(Team team, Collection<Long> user_id);
 
     Optional<TeamUser> findByTeamAndUser(Team team, User user);
     Optional<TeamUser> findByTeamTeamIdAndUserId(Long teamId, Long userId);    boolean existsByTeamAndUser(Team team, User user);
 
     List<TeamUser> findAllByUser(User user);
     List<TeamUser> findAllByTeam(Team team);
+
+//    @Query(value = "UPDATE team_user tu " +
+//            "SET tu.chat_read_at = :lastReadAt " +
+//            "WHERE tu.user_id = :userId " +
+//            "AND tu.team_id IN :teamIds", nativeQuery = true)
+//    @Modifying
+//    void updateChatReadAtBulk(@Param("userId") Long userId, @Param("teamIds") List<Long> teamIds, @Param("lastReadAt") LocalDateTime lastReadAt);
+
 //    @Query(" SELECT tu.user.userId FROM TeamUser tu WHERE tu.team.teamId = :teamId ")
 //    List<Long> findTeamUserIdsByTeam(Long teamId);
 

--- a/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
+++ b/src/main/java/com/github/aico/repository/team_user/TeamUserRepository.java
@@ -25,6 +25,11 @@ public interface TeamUserRepository extends JpaRepository<TeamUser,Long>, QTeamU
 
     List<TeamUser> findAllByUser(User user);
     List<TeamUser> findAllByTeam(Team team);
+//    @Query(" SELECT tu.user.userId FROM TeamUser tu WHERE tu.team.teamId = :teamId ")
+//    List<Long> findTeamUserIdsByTeam(Long teamId);
+
+//    @Query(" SELECT tu.team.teamId FROM TeamUser tu WHERE tu.user.userId = :userId ")
+//    List<Long> findTeamIdsByUser(Long userId);
 //    @Query("SELECT tu FROM TeamUser tu JOIN FETCH tu.user WHERE tu.team = :team")
 //    List<TeamUser> findAllByTeamFetchUser(Team team);
 //    @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/github/aico/repository/user/User.java
+++ b/src/main/java/com/github/aico/repository/user/User.java
@@ -36,6 +36,8 @@ public class User extends BaseEntity {
     private String profile;
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL,orphanRemoval = true, fetch = FetchType.LAZY)
     private List<UserRole> userRoles;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL,orphanRemoval = true, fetch = FetchType.LAZY)
+    private UserProfileImage userProfileImage;
 
     public static User from(SignUpRequest signUpRequest) {
         return User.builder()

--- a/src/main/java/com/github/aico/repository/user/UserRepository.java
+++ b/src/main/java/com/github/aico/repository/user/UserRepository.java
@@ -1,9 +1,12 @@
 package com.github.aico.repository.user;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +16,6 @@ public interface UserRepository extends JpaRepository<User,Long>,QUserRepository
 
     boolean existsByEmail(String email);
     boolean existsByNickname (String nickname);
+    @EntityGraph(attributePaths = {"userProfileImage"})
+    List<User> findAllByIdIn(Collection<Long> id);
 }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -222,6 +222,7 @@ public class AuthService {
 
         // 새로운 팀 유저 추가
         TeamUser teamUser = TeamUser.of(joinTeam, saveUser, TeamRole.MEMBER);
+        redisUtil.invalidateTeamIdsCache(saveUser.getUserId());
         teamUserRepository.save(teamUser);
 
     }

--- a/src/main/java/com/github/aico/service/auth/AuthService.java
+++ b/src/main/java/com/github/aico/service/auth/AuthService.java
@@ -110,6 +110,7 @@ public class AuthService {
         //팀가입으로 회원가입하는 경우
         if (token !=null){
            joinTeam(token,signUpRequest,saveUser);
+
         }
         return new ResponseDto(HttpStatus.CREATED.value(),user.getNickname()+"님 Ai-Co 회원가입이 완료되었습니다.");
     }
@@ -201,6 +202,7 @@ public class AuthService {
     private void joinTeam(String token, SignUpRequest signUpRequest,User saveUser) {
         String tokenEmail = jwtTokenProvider.getEmail(token);
         Long tokenTeamId = jwtTokenProvider.getTeamId(token);
+        redisUtil.invalidateUsersCache(tokenTeamId);
 
         // Redis에서 이메일로 저장된 데이터가 없거나 이메일이 일치하지 않으면 예외 처리
         if (redisUtil.getData(tokenEmail) == null || !tokenEmail.equals(signUpRequest.getEmail())) {
@@ -209,7 +211,7 @@ public class AuthService {
 
         // 초대 토큰에 대한 데이터 삭제
         redisUtil.deleteData(tokenEmail);
-
+        redisUtil.invalidateUsersCache(tokenTeamId);
         // 팀 ID로 팀 조회
         Team joinTeam = teamRepository.findById(tokenTeamId)
                 .orElseThrow(() -> new NotFoundException("가입하려는 팀이 존재하지 않습니다."));

--- a/src/main/java/com/github/aico/service/chat/ChatService.java
+++ b/src/main/java/com/github/aico/service/chat/ChatService.java
@@ -43,11 +43,11 @@ public class ChatService {
 
     @Transactional
     public ResponseDto getTeamChatListResult(User user , Long teamId, Integer page) {
-        log.info("시작");
         List<Chatting> chattings = redisUtil.getMessageListFromRedis(teamId);
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(()-> new NotFoundException(teamId + "에 해당하는 팀은 존재하지 않습니다."));
         //채팅 리스트 불러오기 전에 redis에 저장되어 있는 채팅 db에 저장
+        //불러온 값이 비어있으면 실행할 필요가 없으니 비어있지 않을 때 조건문 걸기
         if (!chattings.isEmpty()){
             Set<Long> userIds = chattings.stream().map(Chatting::getUserId).collect(Collectors.toSet());
             Map<Long, User> userMap = userRepository.findAllByIdIn(userIds).stream()
@@ -68,22 +68,14 @@ public class ChatService {
                     })
                     .toList();
             redisUtil.removeChattingFromRedis(teamId);
-//            List<Chat> historyChats = chattings.stream()
-//                    .map(chat -> {
-//                        User findUser = userRepository.findById(chat.getUserId())
-//                                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
-//                        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,findUser)
-//                                .orElseThrow(()-> new NotFoundException("팀에 해당되어 있지 않은 유저가 있습니다."));
-//                        return Chat.of(chat, teamUser);
-//                    })
-//                    .toList();
+
             chatRepository.saveAllBatch(historyChats);
         }
         boolean exists = teamUserRepository.existsByTeamAndUser(team,user);
         if (!exists){
             throw new NotFoundException(teamId + "에 해당하는 유저가 아닙니다.");
         }
-        Pageable pageable = PageRequest.of(page,10,Sort.by( Sort.Direction.DESC,"createdAt"));
+        Pageable pageable = PageRequest.of(page,10,Sort.by( Sort.Direction.DESC,"createdAtMillis"));
         List<TeamUser> teamUsers = teamUserRepository.findTeamUsersByTeamFetchUser(team);
         Page<Chat> chats = chatRepository.findByTeamUserInOrderByCreatedAtMillisDesc(teamUsers,pageable);
         Page<ChatResponse> chatResponses = chats.map(ChatResponse::from);

--- a/src/main/java/com/github/aico/service/chat/ChatService.java
+++ b/src/main/java/com/github/aico/service/chat/ChatService.java
@@ -26,6 +26,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,21 +43,40 @@ public class ChatService {
 
     @Transactional
     public ResponseDto getTeamChatListResult(User user , Long teamId, Integer page) {
+        log.info("시작");
         List<Chatting> chattings = redisUtil.getMessageListFromRedis(teamId);
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(()-> new NotFoundException(teamId + "에 해당하는 팀은 존재하지 않습니다."));
         //채팅 리스트 불러오기 전에 redis에 저장되어 있는 채팅 db에 저장
         if (!chattings.isEmpty()){
-            redisUtil.removeChattingFromRedis(teamId);
+            Set<Long> userIds = chattings.stream().map(Chatting::getUserId).collect(Collectors.toSet());
+            Map<Long, User> userMap = userRepository.findAllByIdIn(userIds).stream()
+                    .collect(Collectors.toMap(User::getUserId, Function.identity()));
+            Map<Long, TeamUser> teamUserMap = teamUserRepository.findByTeamAndUserIdIn(team, userIds).stream()
+                    .collect(Collectors.toMap(tu -> tu.getUser().getUserId(), Function.identity()));
             List<Chat> historyChats = chattings.stream()
                     .map(chat -> {
-                        User findUser = userRepository.findById(chat.getUserId())
-                                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
-                        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,findUser)
-                                .orElseThrow(()-> new NotFoundException("팀에 해당되어 있지 않은 유저가 있습니다."));
+                        User foundUser = userMap.get(chat.getUserId());
+                        if (foundUser == null) {
+                            throw new NotFoundException("유저를 찾을 수 없습니다: " + chat.getUserId());
+                        }
+                        TeamUser teamUser = teamUserMap.get(chat.getUserId());
+                        if (teamUser == null) {
+                            throw new NotFoundException("팀에 해당되지 않은 유저가 있습니다: " + chat.getUserId());
+                        }
                         return Chat.of(chat, teamUser);
                     })
                     .toList();
+            redisUtil.removeChattingFromRedis(teamId);
+//            List<Chat> historyChats = chattings.stream()
+//                    .map(chat -> {
+//                        User findUser = userRepository.findById(chat.getUserId())
+//                                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
+//                        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,findUser)
+//                                .orElseThrow(()-> new NotFoundException("팀에 해당되어 있지 않은 유저가 있습니다."));
+//                        return Chat.of(chat, teamUser);
+//                    })
+//                    .toList();
             chatRepository.saveAllBatch(historyChats);
         }
         boolean exists = teamUserRepository.existsByTeamAndUser(team,user);

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -50,12 +50,15 @@ public class ChattingService {
     //유저가 채팅방에서 끊기고 연결된 시간
     @Transactional
     public void roomInactiveUserResult(ActiveTeamUser activeTeamUser) {
-        Team team = teamRepository.findById(activeTeamUser.getTeamId())
-                        .orElseThrow(()-> new NotFoundException("팀을 찾을 수 없습니다."));
-        User user = userRepository.findById(activeTeamUser.getUserId())
-                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
-        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,user)
-                .orElseThrow(()-> new NotFoundException("팀유저를 찾을 수 없습니다."));
-        teamUser.updateChatReadAt();
+        activeTeamUser.saveLastReadAt();
+        redisUtil.addTeamLastReadAt(activeTeamUser);
+
+//        Team team = teamRepository.findById(activeTeamUser.getTeamId())
+//                        .orElseThrow(()-> new NotFoundException("팀을 찾을 수 없습니다."));
+//        User user = userRepository.findById(activeTeamUser.getUserId())
+//                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
+//        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,user)
+//                .orElseThrow(()-> new NotFoundException("팀유저를 찾을 수 없습니다."));
+//        teamUser.updateChatReadAt();
     }
 }

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -52,14 +52,9 @@ public class ChattingService {
     public void roomInactiveUserResult(ActiveTeamUser activeTeamUser) {
         activeTeamUser.saveLastReadAt();
         log.info(activeTeamUser.getLastReadAt()+ "시간");
+        //redis에 저장해두었다가 팀 불러올 때 db에 저장
         redisUtil.addTeamLastReadAt(activeTeamUser);
 
-//        Team team = teamRepository.findById(activeTeamUser.getTeamId())
-//                        .orElseThrow(()-> new NotFoundException("팀을 찾을 수 없습니다."));
-//        User user = userRepository.findById(activeTeamUser.getUserId())
-//                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
-//        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,user)
-//                .orElseThrow(()-> new NotFoundException("팀유저를 찾을 수 없습니다."));
-//        teamUser.updateChatReadAt();
+
     }
 }

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -37,7 +37,8 @@ public class ChattingService {
         redisUtil.addChatting(chatting);
 
         messagingTemplate.convertAndSend("/topic/room/" + chatting.getTeamId(), chatting);
-        List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(chatting.getTeamId());
+//        List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(chatting.getTeamId());
+        List<Long> userIds = redisUtil.getUserIdByTeamId(chatting.getTeamId());
         if (!userIds.isEmpty()){
             for (Long userId : userIds){
                 messagingTemplate.convertAndSend("/topic/toggle/" + userId,true);

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -10,11 +10,13 @@ import com.github.aico.repository.user.User;
 import com.github.aico.repository.user.UserRepository;
 import com.github.aico.service.exceptions.NotFoundException;
 import com.github.aico.service.redis.RedisUtil;
+import com.github.aico.web.dto.chat.request.ActiveTeamUser;
 import com.github.aico.web.dto.chat.request.Chatting;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -25,10 +27,27 @@ import java.time.LocalDateTime;
 public class ChattingService {
     private final SimpMessagingTemplate messagingTemplate;
     private final RedisUtil redisUtil;
+    private final TeamUserRepository teamUserRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
 
     public void sendChatting(Chatting chatting) {
         chatting.saveCreatedAt();
         redisUtil.addChatting(chatting);
         messagingTemplate.convertAndSend("/topic/room/" + chatting.getTeamId(), chatting);
     }
+
+    //유저가 채팅방에서 끊긴 시간
+    @Transactional
+    public void roomInactiveUserResult(ActiveTeamUser activeTeamUser) {
+        Team team = teamRepository.findById(activeTeamUser.getTeamId())
+                        .orElseThrow(()-> new NotFoundException("팀을 찾을 수 없습니다."));
+        User user = userRepository.findById(activeTeamUser.getUserId())
+                .orElseThrow(()-> new NotFoundException("유저를 찾을 수 없습니다."));
+        TeamUser teamUser = teamUserRepository.findByTeamAndUser(team,user)
+                .orElseThrow(()-> new NotFoundException("팀유저를 찾을 수 없습니다."));
+        teamUser.updateChatReadAt();
+    }
+
+
 }

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -51,6 +51,7 @@ public class ChattingService {
     @Transactional
     public void roomInactiveUserResult(ActiveTeamUser activeTeamUser) {
         activeTeamUser.saveLastReadAt();
+        log.info(activeTeamUser.getLastReadAt()+ "시간");
         redisUtil.addTeamLastReadAt(activeTeamUser);
 
 //        Team team = teamRepository.findById(activeTeamUser.getTeamId())

--- a/src/main/java/com/github/aico/service/chatting/ChattingService.java
+++ b/src/main/java/com/github/aico/service/chatting/ChattingService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +35,18 @@ public class ChattingService {
     public void sendChatting(Chatting chatting) {
         chatting.saveCreatedAt();
         redisUtil.addChatting(chatting);
+
         messagingTemplate.convertAndSend("/topic/room/" + chatting.getTeamId(), chatting);
+        List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(chatting.getTeamId());
+        if (!userIds.isEmpty()){
+            for (Long userId : userIds){
+                messagingTemplate.convertAndSend("/topic/toggle/" + userId,true);
+            }
+        }
+
     }
 
-    //유저가 채팅방에서 끊긴 시간
+    //유저가 채팅방에서 끊기고 연결된 시간
     @Transactional
     public void roomInactiveUserResult(ActiveTeamUser activeTeamUser) {
         Team team = teamRepository.findById(activeTeamUser.getTeamId())
@@ -48,6 +57,4 @@ public class ChattingService {
                 .orElseThrow(()-> new NotFoundException("팀유저를 찾을 수 없습니다."));
         teamUser.updateChatReadAt();
     }
-
-
 }

--- a/src/main/java/com/github/aico/service/redis/RedisUtil.java
+++ b/src/main/java/com/github/aico/service/redis/RedisUtil.java
@@ -102,7 +102,6 @@ public class RedisUtil {
         longRedisTemplate.delete(key);
     }
     public void saveTeamChatting(Long userId) {
-
         List<Long> teamIds =  getTeamIdByUserId(userId);
         List<Team> teams = teamRepository.findAllById(teamIds);
         teams.forEach(dbTeam -> processTeamChatting(dbTeam));

--- a/src/main/java/com/github/aico/service/redis/RedisUtil.java
+++ b/src/main/java/com/github/aico/service/redis/RedisUtil.java
@@ -149,13 +149,14 @@ public class RedisUtil {
     }
     public List<ActiveTeamUser> getTeamLastReadAt(Long userId){
         String pattern = "team_user_inactive:*_" + userId;
-        Set<String> keys = chattingRedisTemplate.keys(pattern);
+        Set<String> keys = activeTeamUserRedisTemplate.keys(pattern);
         ValueOperations<String, ActiveTeamUser> ops = activeTeamUserRedisTemplate.opsForValue();
         return keys.stream()
                 .map(ops::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
+
     public void removeAllTeamLastReadAtByUserId(Long userId) {
         String pattern = "team_user_inactive:*_" + userId;
         Set<String> keys = activeTeamUserRedisTemplate.keys(pattern);
@@ -166,6 +167,24 @@ public class RedisUtil {
             log.info("No keys found to delete for user {}", userId);
         }
     }
+    public List<ActiveTeamUser> getTeamLastReadAtAll(){
+        String pattern = "team_user_inactive:*_*";
+        Set<String> keys = activeTeamUserRedisTemplate.keys(pattern);
+        ValueOperations<String, ActiveTeamUser> ops = activeTeamUserRedisTemplate.opsForValue();
+        return keys.stream()
+                .map(ops::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+    public void removeAllTeamLastReadAt() {
+        String pattern = "team_user_inactive:*_*";
+        Set<String> keys = activeTeamUserRedisTemplate.keys(pattern);
+        if (keys != null && !keys.isEmpty()) {
+            activeTeamUserRedisTemplate.delete(keys);
+
+        }
+    }
+
 
 
     public List<Chatting> getMessageListFromRedis(Long teamId) {

--- a/src/main/java/com/github/aico/service/redis/RedisUtil.java
+++ b/src/main/java/com/github/aico/service/redis/RedisUtil.java
@@ -72,17 +72,17 @@ public class RedisUtil {
         return allChatting;
     }
 
-//    public List<Long> getUserIdByTeamId(Long teamId){
-//        String key  = "team_user" + teamId;
-//        Set<Long> teamUserIds = longRedisTemplate.opsForSet().members(key);
-//        if (teamUserIds.isEmpty()){
-//            List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(teamId);
-//            longRedisTemplate.opsForSet().add(key,userIds.toArray(new Long[0]));
-//            longRedisTemplate.expire(key,24*60*60, TimeUnit.SECONDS);
-//            return userIds;
-//        }
-//        return teamUserIds.stream().toList();
-//    }
+    public List<Long> getUserIdByTeamId(Long teamId){
+        String key  = "team_user" + teamId;
+        Set<Long> teamUserIds = longRedisTemplate.opsForSet().members(key);
+        if (teamUserIds.isEmpty()){
+            List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(teamId);
+            longRedisTemplate.opsForSet().add(key,userIds.toArray(new Long[0]));
+            longRedisTemplate.expire(key,24*60*60, TimeUnit.SECONDS);
+            return userIds;
+        }
+        return teamUserIds.stream().toList();
+    }
     public List<Long> getTeamIdByUserId(Long userId){
         String key = "user_team" + userId;
 
@@ -101,6 +101,10 @@ public class RedisUtil {
         String key = "user_team" + userId;
         longRedisTemplate.delete(key);
         log.info("Invalidated Redis cache for user {}", userId);
+    }
+    public void invalidateUsersCache(Long teamId) {
+        String key = "team_user" + teamId;
+        longRedisTemplate.delete(key);
     }
     public void saveTeamChatting(Long userId) {
 

--- a/src/main/java/com/github/aico/service/redis/RedisUtil.java
+++ b/src/main/java/com/github/aico/service/redis/RedisUtil.java
@@ -9,20 +9,17 @@ import com.github.aico.repository.team_user.TeamUserRepository;
 import com.github.aico.repository.user.User;
 import com.github.aico.repository.user.UserRepository;
 import com.github.aico.service.exceptions.NotFoundException;
+import com.github.aico.web.dto.chat.request.ActiveTeamUser;
 import com.github.aico.web.dto.chat.request.Chatting;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +32,8 @@ public class RedisUtil {
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
     private final ChatRepository chatRepository;
-    private final String team = "team";
+    private final RedisTemplate<String, ActiveTeamUser> activeTeamUserRedisTemplate;
+    private final String team = "team:";
 
     public String getData(String key){
         ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
@@ -53,10 +51,7 @@ public class RedisUtil {
     public void deleteData(String key){//지정된 키(key)에 해당하는 데이터를 Redis에서 삭제하는 메서드
         redisTemplate.delete(key);
     }
-    public void addChatting(Chatting chatting) {
-        String key = team + chatting.getTeamId().toString();
-        chattingRedisTemplate.opsForList().rightPush(key, chatting);
-    }
+
 
     public List<Chatting> getAllMessage(){
         String pattern = team+"*";
@@ -73,7 +68,7 @@ public class RedisUtil {
     }
 
     public List<Long> getUserIdByTeamId(Long teamId){
-        String key  = "team_user" + teamId;
+        String key  = "team_user:" + teamId;
         Set<Long> teamUserIds = longRedisTemplate.opsForSet().members(key);
         if (teamUserIds.isEmpty()){
             List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(teamId);
@@ -84,13 +79,13 @@ public class RedisUtil {
         return teamUserIds.stream().toList();
     }
     public List<Long> getTeamIdByUserId(Long userId){
-        String key = "user_team" + userId;
+        String key = "user_team:" + userId;
 
         Set<Long> teamIds = longRedisTemplate.opsForSet().members(key);
         log.info("Redis teamIds for user {}: {}", userId, teamIds);
         if (teamIds.isEmpty()){
             List<Long> teamIdsByDb = teamUserRepository.findTeamIdsByUser(userId);
-            log.info("DB teamIds for user {}: {}", userId, teamIdsByDb);
+
             longRedisTemplate.opsForSet().add(key,teamIdsByDb.toArray(new Long[0]));
             longRedisTemplate.expire(key,24*60*60,TimeUnit.SECONDS);
             return teamIdsByDb;
@@ -98,12 +93,12 @@ public class RedisUtil {
         return teamIds.stream().toList();
     }
     public void invalidateTeamIdsCache(Long userId) {
-        String key = "user_team" + userId;
+        String key = "user_team:" + userId;
         longRedisTemplate.delete(key);
         log.info("Invalidated Redis cache for user {}", userId);
     }
     public void invalidateUsersCache(Long teamId) {
-        String key = "team_user" + teamId;
+        String key = "team_user:" + teamId;
         longRedisTemplate.delete(key);
     }
     public void saveTeamChatting(Long userId) {
@@ -142,6 +137,36 @@ public class RedisUtil {
         Set<String> keys = chattingRedisTemplate.keys(pattern);
         chattingRedisTemplate.delete(keys);
     }
+    public void addChatting(Chatting chatting) {
+        String key = team + chatting.getTeamId().toString();
+        chattingRedisTemplate.opsForList().rightPush(key, chatting);
+    }
+    public void addTeamLastReadAt(ActiveTeamUser activeTeamUser){
+        String key = "team_user_inactive:"+activeTeamUser.getTeamId() +"_"+activeTeamUser.getUserId();
+        log.info("키 값: " + key);
+        ValueOperations<String, ActiveTeamUser> ops = activeTeamUserRedisTemplate.opsForValue();
+        ops.set(key, activeTeamUser);
+    }
+    public List<ActiveTeamUser> getTeamLastReadAt(Long userId){
+        String pattern = "team_user_inactive:*_" + userId;
+        Set<String> keys = chattingRedisTemplate.keys(pattern);
+        ValueOperations<String, ActiveTeamUser> ops = activeTeamUserRedisTemplate.opsForValue();
+        return keys.stream()
+                .map(ops::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+    public void removeAllTeamLastReadAtByUserId(Long userId) {
+        String pattern = "team_user_inactive:*_" + userId;
+        Set<String> keys = activeTeamUserRedisTemplate.keys(pattern);
+        if (keys != null && !keys.isEmpty()) {
+            activeTeamUserRedisTemplate.delete(keys);
+            log.info("Deleted {} keys for user {}", keys.size(), userId);
+        } else {
+            log.info("No keys found to delete for user {}", userId);
+        }
+    }
+
 
     public List<Chatting> getMessageListFromRedis(Long teamId) {
         String key = team + teamId.toString();

--- a/src/main/java/com/github/aico/service/redis/RedisUtil.java
+++ b/src/main/java/com/github/aico/service/redis/RedisUtil.java
@@ -1,7 +1,17 @@
 package com.github.aico.service.redis;
 
+import com.github.aico.repository.chat.Chat;
+import com.github.aico.repository.chat.ChatRepository;
+import com.github.aico.repository.team.Team;
+import com.github.aico.repository.team.TeamRepository;
+import com.github.aico.repository.team_user.TeamUser;
+import com.github.aico.repository.team_user.TeamUserRepository;
+import com.github.aico.repository.user.User;
+import com.github.aico.repository.user.UserRepository;
+import com.github.aico.service.exceptions.NotFoundException;
 import com.github.aico.web.dto.chat.request.Chatting;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -12,12 +22,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RedisUtil {
     private final StringRedisTemplate redisTemplate;
     private final RedisTemplate<String, Chatting> chattingRedisTemplate;
+    private final RedisTemplate<String,Long> longRedisTemplate;
+    private final TeamUserRepository teamUserRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+    private final ChatRepository chatRepository;
     private final String team = "team";
 
     public String getData(String key){
@@ -54,6 +71,68 @@ public class RedisUtil {
         }
         return allChatting;
     }
+
+//    public List<Long> getUserIdByTeamId(Long teamId){
+//        String key  = "team_user" + teamId;
+//        Set<Long> teamUserIds = longRedisTemplate.opsForSet().members(key);
+//        if (teamUserIds.isEmpty()){
+//            List<Long> userIds = teamUserRepository.findTeamUserIdsByTeam(teamId);
+//            longRedisTemplate.opsForSet().add(key,userIds.toArray(new Long[0]));
+//            longRedisTemplate.expire(key,24*60*60, TimeUnit.SECONDS);
+//            return userIds;
+//        }
+//        return teamUserIds.stream().toList();
+//    }
+    public List<Long> getTeamIdByUserId(Long userId){
+        String key = "user_team" + userId;
+
+        Set<Long> teamIds = longRedisTemplate.opsForSet().members(key);
+        log.info("Redis teamIds for user {}: {}", userId, teamIds);
+        if (teamIds.isEmpty()){
+            List<Long> teamIdsByDb = teamUserRepository.findTeamIdsByUser(userId);
+            log.info("DB teamIds for user {}: {}", userId, teamIdsByDb);
+            longRedisTemplate.opsForSet().add(key,teamIdsByDb.toArray(new Long[0]));
+            longRedisTemplate.expire(key,24*60*60,TimeUnit.SECONDS);
+            return teamIdsByDb;
+        }
+        return teamIds.stream().toList();
+    }
+    public void invalidateTeamIdsCache(Long userId) {
+        String key = "user_team" + userId;
+        longRedisTemplate.delete(key);
+        log.info("Invalidated Redis cache for user {}", userId);
+    }
+    public void saveTeamChatting(Long userId) {
+
+        List<Long> teamIds =  getTeamIdByUserId(userId);
+        List<Team> teams = teamRepository.findAllById(teamIds);
+        teams.forEach(dbTeam -> processTeamChatting(dbTeam));
+
+    }
+
+    private void processTeamChatting(Team dbTeam) {
+        Long teamId = dbTeam.getTeamId();
+        List<Chatting> chattings = getMessageListFromRedis(teamId);
+        if (!chattings.isEmpty()) {
+            removeChattingFromRedis(teamId);
+            List<Chat> historyChats = chattings.stream()
+                    .map(chat -> createChat(chat, dbTeam))
+                    .toList();
+            chatRepository.saveAllBatch(historyChats);
+        }
+    }
+
+    private Chat createChat(Chatting chat, Team dbTeam) {
+        User findUser = userRepository.findById(chat.getUserId())
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        TeamUser teamUser = teamUserRepository.findByTeamAndUser(dbTeam, findUser)
+                .orElseThrow(() -> new NotFoundException("팀에 해당되어 있지 않은 유저가 있습니다."));
+        return Chat.of(chat, teamUser);
+    }
+
+
+
+
     public void deleteAllMessage(){
         String pattern = team+"*";
         Set<String> keys = chattingRedisTemplate.keys(pattern);

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -15,6 +15,7 @@ import com.github.aico.service.exceptions.BadRequestException;
 import com.github.aico.service.exceptions.NotFoundException;
 import com.github.aico.web.dto.auth.request.EmailDuplicate;
 import com.github.aico.web.dto.base.ResponseDto;
+import com.github.aico.web.dto.chat.request.ActiveTeamUser;
 import com.github.aico.web.dto.team.request.MakeTeam;
 import com.github.aico.web.dto.team.response.TeamsResponse;
 import com.github.aico.web.dto.teamUser.request.LeaveTeamMember;
@@ -55,7 +56,12 @@ public class TeamService {
     /**
      * 내 팀 리스트 조회
      * */
+    @Transactional
     public ResponseDto getMyTeamListResult(User user,Integer page) {
+        List<ActiveTeamUser> activeTeamUsers = redisUtil.getTeamLastReadAt(user.getUserId());
+        if (!activeTeamUsers.isEmpty()){
+            activeUserSave(activeTeamUsers,user);
+        }
 
         Pageable pageable = PageRequest.of(page,10);
         log.info("N+1테스트 시작");
@@ -80,6 +86,25 @@ public class TeamService {
         });
 
         return new ResponseDto(HttpStatus.OK.value(),user.getNickname()+"님의 team 조회 성공",myTeamResponse);
+    }
+    public void activeUserSave(List<ActiveTeamUser> activeTeamUsers,User user){
+        List<Long> teamIds = activeTeamUsers.stream()
+                .map(ActiveTeamUser::getTeamId)
+                .toList();
+        log.info("teamIds: " + teamIds);
+        List<TeamUser> teamUserList = teamUserRepository.findByUserAndTeamTeamIdIn(user,teamIds);
+        log.info("teamUserList: " + teamUserList);
+        Map<Long, ActiveTeamUser> activeTeamUserMap = activeTeamUsers.stream()
+                .collect(Collectors.toMap(ActiveTeamUser::getTeamId, activeTeamUser -> activeTeamUser));
+
+        // TeamUser 업데이트
+        teamUserList.forEach(teamUser -> {
+            ActiveTeamUser activeTeamUser = activeTeamUserMap.get(teamUser.getTeam().getTeamId());
+            if (activeTeamUser != null) {
+                teamUser.changeChatReadAt(activeTeamUser.getLastReadAt());
+            }
+        });
+        redisUtil.removeAllTeamLastReadAtByUserId(user.getUserId());
     }
     /**
      * 팀 만들기

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -65,21 +65,20 @@ public class TeamService {
         log.info("N+1테스트 끝");
 //        Page<Team>  myTeam = myTeamUser.map(TeamUser::getTeam);
         List<Long> teamIds = redisUtil.getTeamIdByUserId(user.getUserId());
-        log.info("그럼 여기?");
+        //redis에 저장된 채팅들 db에 저장하기
         redisUtil.saveTeamChatting(user.getUserId());
-        log.info("여기가 시작인가?");
+        //팀별로 가장 최근 메시지 시간 가져오기
         List<TeamLatestChatTimeDto> teamLatestChatTimeDtos = chatRepository.findLatestChatTimesByTeamIds(teamIds);
-        log.info("TeamLatestChatTimeDtos: {}", teamLatestChatTimeDtos);
+        //map으로 변환
         Map<Long, LocalDateTime> lastMessageAtMap = teamLatestChatTimeDtos.stream()
                 .collect(Collectors.toMap(TeamLatestChatTimeDto::getTeamId, TeamLatestChatTimeDto::getLatestTime));
-        log.info("LastMessageAtMap: {}", lastMessageAtMap);
-
+        //TeamResponse에 추가
         Page<TeamsResponse> myTeamResponse = myTeamUser.map(teamUser -> {
             Team team = teamUser.getTeam();
             LocalDateTime lastMessageAt = lastMessageAtMap.getOrDefault(team.getTeamId(), null);
             return TeamsResponse.of(team, teamUser, lastMessageAt);
         });
-//        Page<TeamsResponse> myTeamResponse = myTeam.map();
+
         return new ResponseDto(HttpStatus.OK.value(),user.getNickname()+"님의 team 조회 성공",myTeamResponse);
     }
     /**
@@ -168,6 +167,7 @@ public class TeamService {
         else {
             handleMemberLeave(user, leaveUserId, teamUser);
         }
+        redisUtil.invalidateUsersCache(teamId);
         return new ResponseDto(HttpStatus.NO_CONTENT.value(), "팀 탈퇴처리되었습니다.");
     }
 
@@ -202,6 +202,7 @@ public class TeamService {
             //회원가입은 되어 있고 팀 가입이 필요할 때
             //회원가입도 안되어 있을 때
             getResponse(teamId, tokenEmail, response,inviteToken);
+            redisUtil.invalidateUsersCache(teamId);
 
         }catch (IOException ioe){
             throw new NotFoundException("잘못된 페이지 요청입니다.");

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -89,22 +89,41 @@ public class TeamService {
         return new ResponseDto(HttpStatus.OK.value(),user.getNickname()+"님의 team 조회 성공",myTeamResponse);
     }
     public void activeUserSave(List<ActiveTeamUser> activeTeamUsers,User user){
-        List<Long> teamIds = activeTeamUsers.stream()
-                .map(ActiveTeamUser::getTeamId)
-                .toList();
-        log.info("teamIds: " + teamIds);
-        List<TeamUser> teamUserList = teamUserRepository.findByUserAndTeamTeamIdIn(user,teamIds);
-        log.info("teamUserList: " + teamUserList);
-        Map<Long, ActiveTeamUser> activeTeamUserMap = activeTeamUsers.stream()
-                .collect(Collectors.toMap(ActiveTeamUser::getTeamId, activeTeamUser -> activeTeamUser));
+//        List<Long> teamIds = activeTeamUsers.stream()
+//                .map(ActiveTeamUser::getTeamId)
+//                .toList();
+//        log.info("teamIds: " + teamIds);
+//        List<TeamUser> teamUserList = teamUserRepository.findByUserAndTeamTeamIdIn(user,teamIds);
+//        log.info("teamUserList: " + teamUserList);
+//        Map<Long, ActiveTeamUser> activeTeamUserMap = activeTeamUsers.stream()
+//                .collect(Collectors.toMap(ActiveTeamUser::getTeamId, activeTeamUser -> activeTeamUser));
+//
+//        // TeamUser 업데이트
+//        teamUserList.forEach(teamUser -> {
+//            ActiveTeamUser activeTeamUser = activeTeamUserMap.get(teamUser.getTeam().getTeamId());
+//            if (activeTeamUser != null) {
+//                teamUser.changeChatReadAt(activeTeamUser.getLastReadAt());
+//            }
+//        });
+        Map<Long, LocalDateTime> teamIdToLastReadAt = activeTeamUsers.stream()
+                .filter(atu -> atu.getTeamId() != null && atu.getLastReadAt() != null)
+                .collect(Collectors.toMap(
+                        ActiveTeamUser::getTeamId,
+                        ActiveTeamUser::getLastReadAt,
+                        (existing, replacement) -> existing
+                ));
 
-        // TeamUser 업데이트
-        teamUserList.forEach(teamUser -> {
-            ActiveTeamUser activeTeamUser = activeTeamUserMap.get(teamUser.getTeam().getTeamId());
-            if (activeTeamUser != null) {
-                teamUser.changeChatReadAt(activeTeamUser.getLastReadAt());
-            }
-        });
+        if (teamIdToLastReadAt.isEmpty()) {
+            log.warn("No valid ActiveTeamUser data to update for user: {}", user.getUserId());
+            redisUtil.removeAllTeamLastReadAtByUserId(user.getUserId());
+            return;
+        }
+
+        log.info("teamIdToLastReadAt: {}", teamIdToLastReadAt);
+        teamUserRepository.updateChatReadAtBulk(user.getUserId(), teamIdToLastReadAt);
+
+
+
         redisUtil.removeAllTeamLastReadAtByUserId(user.getUserId());
     }
 //    @Scheduled(fixedRate = 300000)

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -60,6 +60,7 @@ public class TeamService {
     @Transactional
     public ResponseDto getMyTeamListResult(User user,Integer page) {
         List<ActiveTeamUser> activeTeamUsers = redisUtil.getTeamLastReadAt(user.getUserId());
+        //유저가 채팅방 나간시간 또는 접속한 시간 저장
         if (!activeTeamUsers.isEmpty()){
             activeUserSave(activeTeamUsers,user);
         }
@@ -121,8 +122,6 @@ public class TeamService {
 
         log.info("teamIdToLastReadAt: {}", teamIdToLastReadAt);
         teamUserRepository.updateChatReadAtBulk(user.getUserId(), teamIdToLastReadAt);
-
-
 
         redisUtil.removeAllTeamLastReadAtByUserId(user.getUserId());
     }

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -31,6 +31,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,6 +107,48 @@ public class TeamService {
         });
         redisUtil.removeAllTeamLastReadAtByUserId(user.getUserId());
     }
+//    @Scheduled(fixedRate = 300000)
+//    @Scheduled(fixedRate = 60000) // 1분(60,000ms)
+//    @Transactional
+//    public void activeUserSaveAll(){
+//        List<ActiveTeamUser> activeTeamUsers = redisUtil.getTeamLastReadAtAll();
+//        if (!activeTeamUsers.isEmpty()){
+//            Map<Long, List<ActiveTeamUser>> userActiveMap = activeTeamUsers.stream()
+//                    .collect(Collectors.groupingBy(ActiveTeamUser::getUserId));
+//            for (Map.Entry<Long, List<ActiveTeamUser>> entry : userActiveMap.entrySet()) {
+//                Long userId = entry.getKey();
+//                List<ActiveTeamUser> userActiveTeamUsers = entry.getValue();
+//                User user = userRepository.findById(userId).orElse(null);
+//                if (user != null) {
+//                    saveActiveTeamUsers(user, userActiveTeamUsers);
+//                } else {
+//                    log.warn("User not found for userId: {}", userId);
+//                }
+//            }
+//            redisUtil.removeAllTeamLastReadAt();
+//        }
+//
+//    }
+//    private void saveActiveTeamUsers(User user, List<ActiveTeamUser> activeTeamUsers) {
+//        List<Long> teamIds = activeTeamUsers.stream()
+//                .map(ActiveTeamUser::getTeamId)
+//                .toList();
+//        log.info("teamIds for user {}: {}", user.getUserId(), teamIds);
+//
+//        List<TeamUser> teamUserList = teamUserRepository.findByUserAndTeamTeamIdIn(user, teamIds);
+//        log.info("teamUserList for user {}: {}", user.getUserId(), teamUserList);
+//
+//        Map<Long, ActiveTeamUser> activeTeamUserMap = activeTeamUsers.stream()
+//                .collect(Collectors.toMap(ActiveTeamUser::getTeamId, activeTeamUser -> activeTeamUser));
+//
+//        teamUserList.forEach(teamUser -> {
+//            ActiveTeamUser activeTeamUser = activeTeamUserMap.get(teamUser.getTeam().getTeamId());
+//            if (activeTeamUser != null) {
+//                teamUser.changeChatReadAt(activeTeamUser.getLastReadAt());
+//            }
+//        });
+//
+//    }
     /**
      * 팀 만들기
      * */

--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -1,6 +1,8 @@
 package com.github.aico.service.team;
 
 import com.github.aico.config.security.JwtTokenProvider;
+import com.github.aico.repository.chat.ChatRepository;
+import com.github.aico.repository.chat.TeamLatestChatTimeDto;
 import com.github.aico.repository.team.Team;
 import com.github.aico.repository.team.TeamRepository;
 import com.github.aico.repository.team_user.TeamRole;
@@ -32,7 +34,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +46,7 @@ public class TeamService {
     private final TeamUserRepository teamUserRepository;
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+    private final ChatRepository chatRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final JavaMailSender sender;
     @Value("${spring.mail.username}")
@@ -50,15 +56,30 @@ public class TeamService {
      * 내 팀 리스트 조회
      * */
     public ResponseDto getMyTeamListResult(User user,Integer page) {
+
         Pageable pageable = PageRequest.of(page,10);
         log.info("N+1테스트 시작");
         // N+1 문제가 발생하여 @EntityGraph 사용
         // TeamUser 조회할 때마다 Team은 항상 필요하므로 @EntityGraph 를 통해 TeamUser 조회 시 Team 함께 가져온다.
         Page<TeamUser> myTeamUser = teamUserRepository.findAllByUser(user,pageable);
         log.info("N+1테스트 끝");
-        Page<Team>  myTeam = myTeamUser.map(TeamUser::getTeam);
+//        Page<Team>  myTeam = myTeamUser.map(TeamUser::getTeam);
+        List<Long> teamIds = redisUtil.getTeamIdByUserId(user.getUserId());
+        log.info("그럼 여기?");
+        redisUtil.saveTeamChatting(user.getUserId());
+        log.info("여기가 시작인가?");
+        List<TeamLatestChatTimeDto> teamLatestChatTimeDtos = chatRepository.findLatestChatTimesByTeamIds(teamIds);
+        log.info("TeamLatestChatTimeDtos: {}", teamLatestChatTimeDtos);
+        Map<Long, LocalDateTime> lastMessageAtMap = teamLatestChatTimeDtos.stream()
+                .collect(Collectors.toMap(TeamLatestChatTimeDto::getTeamId, TeamLatestChatTimeDto::getLatestTime));
+        log.info("LastMessageAtMap: {}", lastMessageAtMap);
 
-        Page<TeamsResponse> myTeamResponse = myTeam.map(TeamsResponse::from);
+        Page<TeamsResponse> myTeamResponse = myTeamUser.map(teamUser -> {
+            Team team = teamUser.getTeam();
+            LocalDateTime lastMessageAt = lastMessageAtMap.getOrDefault(team.getTeamId(), null);
+            return TeamsResponse.of(team, teamUser, lastMessageAt);
+        });
+//        Page<TeamsResponse> myTeamResponse = myTeam.map();
         return new ResponseDto(HttpStatus.OK.value(),user.getNickname()+"님의 team 조회 성공",myTeamResponse);
     }
     /**
@@ -103,6 +124,7 @@ public class TeamService {
         }
 
         teamRepository.deleteTeamById(teamId);
+        redisUtil.invalidateTeamIdsCache(user.getUserId());
         return new ResponseDto(HttpStatus.NO_CONTENT.value(),"삭제 성공");
     }
     /**
@@ -180,6 +202,7 @@ public class TeamService {
             //회원가입은 되어 있고 팀 가입이 필요할 때
             //회원가입도 안되어 있을 때
             getResponse(teamId, tokenEmail, response,inviteToken);
+
         }catch (IOException ioe){
             throw new NotFoundException("잘못된 페이지 요청입니다.");
         }
@@ -335,6 +358,7 @@ public class TeamService {
         TeamUser teamUser = teamUserRepository.findByTeamAndUser(joinTeam, user).orElse(null);
         if (teamUser == null) {
             List<TeamUser> teamUsers = teamUserRepository.findByTeamWithLockDsl(joinTeam);
+
             if (teamUsers.size() >= 10){
                 response.sendRedirect("http://localhost:3000?code=400"); // http://localhost:3000?code=400
                 return;
@@ -342,6 +366,7 @@ public class TeamService {
             TeamUser joinTeamUser = TeamUser.of(joinTeam, user,TeamRole.MEMBER);
             teamUserRepository.save(joinTeamUser);
             redisUtil.deleteData(tokenEmail);  // 가입 후 토큰 삭제
+            redisUtil.invalidateTeamIdsCache(user.getUserId());
             response.sendRedirect("http://localhost:3000/team/detail/"+teamId); // http://localhost:3000/team/detail/{teamId}
             return;
         }

--- a/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
+++ b/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
@@ -4,6 +4,7 @@ import com.github.aico.repository.user.JwtUser;
 import com.github.aico.repository.user.User;
 import com.github.aico.repository.userDetails.CustomUserDetails;
 import com.github.aico.service.chatting.ChattingService;
+import com.github.aico.web.dto.chat.request.ActiveTeamUser;
 import com.github.aico.web.dto.chat.request.Chatting;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,14 @@ public class ChattingController {
     public void sendChatting(@Payload Chatting chatting) {
         log.info(chatting.getContent());
         chattingService.sendChatting(chatting);
+    }
+    @MessageMapping("/room/active")
+    public void roomActiveUser(@Payload ActiveTeamUser activeTeamUser) {
+        chattingService.roomInactiveUserResult(activeTeamUser);
+    }
+    @MessageMapping("/room/inactive")
+    public void roomInactiveUser(@Payload ActiveTeamUser activeTeamUser) {
+        chattingService.roomInactiveUserResult(activeTeamUser);
     }
 
 }

--- a/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
+++ b/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
@@ -29,6 +29,7 @@ public class ChattingController {
     }
     @MessageMapping("/room/active")
     public void roomActiveUser(@Payload ActiveTeamUser activeTeamUser) {
+        log.info(activeTeamUser.getUserId()+ "유저아이디");
         chattingService.roomInactiveUserResult(activeTeamUser);
     }
     @MessageMapping("/room/inactive")

--- a/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
+++ b/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
@@ -13,6 +13,8 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
+import java.security.Principal;
+
 @Controller
 @RequiredArgsConstructor
 @Slf4j
@@ -21,7 +23,8 @@ public class ChattingController {
     private final ChattingService chattingService;
     @MessageMapping("/room")
     public void sendChatting(@Payload Chatting chatting) {
-        log.info(chatting.getContent());
+
+//        log.info(principal.getName());
         chattingService.sendChatting(chatting);
     }
     @MessageMapping("/room/active")

--- a/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
+++ b/src/main/java/com/github/aico/web/controller/chatting/ChattingController.java
@@ -23,9 +23,9 @@ public class ChattingController {
     private final ChattingService chattingService;
     @MessageMapping("/room")
     public void sendChatting(@Payload Chatting chatting) {
-
 //        log.info(principal.getName());
         chattingService.sendChatting(chatting);
+
     }
     @MessageMapping("/room/active")
     public void roomActiveUser(@Payload ActiveTeamUser activeTeamUser) {
@@ -35,5 +35,6 @@ public class ChattingController {
     public void roomInactiveUser(@Payload ActiveTeamUser activeTeamUser) {
         chattingService.roomInactiveUserResult(activeTeamUser);
     }
+
 
 }

--- a/src/main/java/com/github/aico/web/dto/chat/request/ActiveTeamUser.java
+++ b/src/main/java/com/github/aico/web/dto/chat/request/ActiveTeamUser.java
@@ -1,0 +1,16 @@
+package com.github.aico.web.dto.chat.request;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class ActiveTeamUser {
+    private Long teamId;
+    private Long userId;
+
+}

--- a/src/main/java/com/github/aico/web/dto/chat/request/ActiveTeamUser.java
+++ b/src/main/java/com/github/aico/web/dto/chat/request/ActiveTeamUser.java
@@ -12,5 +12,9 @@ import java.time.LocalDateTime;
 public class ActiveTeamUser {
     private Long teamId;
     private Long userId;
+    private LocalDateTime lastReadAt;
+    public void saveLastReadAt(){
+        this.lastReadAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/github/aico/web/dto/chat/response/ChatResponse.java
+++ b/src/main/java/com/github/aico/web/dto/chat/response/ChatResponse.java
@@ -25,7 +25,7 @@ public class ChatResponse {
         return ChatResponse.builder()
                 .roomId(chat.getTeamUser().getTeam().getTeamId())
                 .chatId(chat.getChatId())
-                .userInfo(UserInfo.from(chat.getTeamUser().getUser()))
+                .userInfo(UserInfo.of(chat.getTeamUser().getUser(),chat.getTeamUser().getUser().getUserProfileImage().getImageUrl()))
                 .content(chat.getContent())
                 .createdAt(chat.getCreatedAtMillis())
                 .build();

--- a/src/main/java/com/github/aico/web/dto/team/response/TeamsResponse.java
+++ b/src/main/java/com/github/aico/web/dto/team/response/TeamsResponse.java
@@ -1,10 +1,14 @@
 package com.github.aico.web.dto.team.response;
 
+import com.github.aico.repository.chat.Chat;
 import com.github.aico.repository.team.Team;
+import com.github.aico.repository.team_user.TeamUser;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -13,11 +17,15 @@ import lombok.ToString;
 public class TeamsResponse {
     private final Long teamId;
     private final String name;
+    private final LocalDateTime lastReadAt;
+    private final LocalDateTime lastMessageAt;
 
-    public static TeamsResponse from(Team team){
+    public static TeamsResponse of(Team team, TeamUser teamUser, LocalDateTime lastMessageAt){
         return TeamsResponse.builder()
                 .teamId(team.getTeamId())
                 .name(team.getTeamName())
+                .lastReadAt(teamUser.getChatReadAt())
+                .lastMessageAt(lastMessageAt)
                 .build();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,8 +40,8 @@ spring:
           auth: true
   data:
     redis:
-      #host: localhost
-      host: ENC(n60mvykJRU2R5SBqLmUiyatj973/jexg) #ENC(4i+ka2OLOJPRQUSzIXfseA6RSvcUhwx7) # 추후 ec2 프라이빗 아이피로 변경 필요2.
+      host: localhost
+      #host: ENC(n60mvykJRU2R5SBqLmUiyatj973/jexg) #ENC(4i+ka2OLOJPRQUSzIXfseA6RSvcUhwx7) # 추후 ec2 프라이빗 아이피로 변경 필요2.
       port: 6379
       password: ENC(4jc8zprzCJTQ3qjGiSwInQ==)
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,14 +12,19 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: none
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
+        flush:
+          mode: COMMIT
+
 #  cache:
 #    type: simple
 
-    properties:
-      hibernate.jdbc.batch_size: 50  # 한 번에 저장할 최대 엔티티 수
-      hibernate.order_inserts: true  # 삽입 순서 최적화
-      hibernate.order_updates: true  # 업데이트 순서 최적화
-      hibernate.flush.mode: COMMIT  # Batch 후 flush 시점 설정
+
 
 
   logging:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,9 +27,7 @@ spring:
 
 
 
-  logging:
-    level:
-      io.netty.resolver.dns: DEBUG
+
 
   mail:
     # Google smtp server 사용
@@ -45,8 +43,8 @@ spring:
           auth: true
   data:
     redis:
-      host: localhost
-      #host: ENC(n60mvykJRU2R5SBqLmUiyatj973/jexg) #ENC(4i+ka2OLOJPRQUSzIXfseA6RSvcUhwx7) # 추후 ec2 프라이빗 아이피로 변경 필요2.
+      #host: localhost
+      host: ENC(n60mvykJRU2R5SBqLmUiyatj973/jexg) #ENC(4i+ka2OLOJPRQUSzIXfseA6RSvcUhwx7) # 추후 ec2 프라이빗 아이피로 변경 필요2.
       port: 6379
       password: ENC(4jc8zprzCJTQ3qjGiSwInQ==)
 
@@ -71,3 +69,7 @@ cloud:
 openai:
   api-key: ENC(HiTnN5L4Y8wbi3RY0tU7/fOwngKkHPmQiimher6CfGIr0yMg3jJUk6uC7BUIGi32SCORd5Z7MgUJXOegXCkk2+2EBChoOfBbnsAC30Z3VkEt8x8uV1uMWnx9K0CCMlUjYLW7FrLnWabvUaGMDmwG3SthILDlk4jRop3OV+VCCoGH5d99BUclFIwrFdfJrjzzxDTSyHEWBDmhxwCVaz2PWO24IBsL/F0R2z5R4dtiLNk=)
   model: gpt-3.5-turbo-0125
+logging:
+  level:
+    io.netty.resolver.dns: DEBUG
+    org.springframework.jdbc: TRACE


### PR DESCRIPTION
chatting

- 유저가 소켓 끊기고 연결되었을 때 socket 통로 열기
1) 유저가 끊겼을 때 db에 바로 저장이 아닌 redis에 저장 후 팀 리스트 불러올 때 한 번에 저장 
*! updateAll이 아닌 jdbcTemplate를 사용해 batchUpdate 적용
- 유저가 최신 메시지 받을 때 구독 받기
1) 유저가 연결상태가 끊어져있을 때의 구독이 되어있는 곳에 최신 메시지가 왔다는 boolean 값 전송
2) 해당 값을 받으면 팀 불러오기를 refresh하여 각 팀들의 최신 메시지와 유저가 각 팀에서 마지막으로 읽은 시간이 전송
- websocket이 연결 끊겼을 때 확인을 위해 EventListener 추가
1) 모종의 이유로 웹소켓 연결 끊겼을 때도 유저 연결 끊긴 시간 redis에 저장
- websocket에 연결도이어 있는 유저 사용을 위해 configureClientInboundChannel 빈 등록
-  HandShake를 통해서 유저가 토큰을 확인 후 websocket 연결하기 추가