### PR TITLE
fix: 팀 가입 시 회원가입 안되었있을 경우 로직을 앞에서 동작하게 수정

### DIFF
--- a/src/main/java/com/github/aico/service/team/TeamService.java
+++ b/src/main/java/com/github/aico/service/team/TeamService.java
@@ -440,6 +440,11 @@ public class TeamService {
             response.sendRedirect("http://localhost:3000?code=401");// http://localhost:3000?code=401
             return;
         }
+        // 회원가입이 되어 있지 않을 때
+        if (user == null) {
+            response.sendRedirect("http://localhost:3000/signup?token="+inviteToken); // http://localhost:3000/signup?token={토큰}
+            return;
+        }
 
         // 회원가입은 되어 있고 팀이 아닐 때
         TeamUser teamUser = teamUserRepository.findByTeamAndUser(joinTeam, user).orElse(null);
@@ -457,11 +462,7 @@ public class TeamService {
             response.sendRedirect("http://localhost:3000/team/detail/"+teamId); // http://localhost:3000/team/detail/{teamId}
             return;
         }
-        // 회원가입이 되어 있지 않을 때
-        if (user == null) {
-            response.sendRedirect("http://localhost:3000/signup?token="+inviteToken); // http://localhost:3000/signup?token={토큰}
-            return;
-        }
+
     }
 
 


### PR DESCRIPTION
fix: 회원가입이 안되어 있을 경우 로직이 더 뒤에 있어 teamUser null인 로직부터 발생해 에러 발생 회원가입이 안되어 있을 경우 로직을 앞에 두어 에러 해결